### PR TITLE
Add codespell-problem-matcher to show codespell errors in actions output

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,6 +90,8 @@ jobs:
               with:
                 python_version: "3.11"
 
+            - uses: codespell-project/codespell-problem-matcher@v1
+
             - name: Run spelling check
               run: poetry run $(make spelling-check --just-print --silent)
 


### PR DESCRIPTION
This adds the `codespell-problem-matcher` so that the error/warning is shown in the file.