### PR TITLE
Change folder in docker file

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,8 +61,8 @@ FROM base AS final
 
 # We need to copy the compiled shared libraries from the builder stage to the correct location so they can be found.
 RUN mkdir -p /usr/lib/x86_64-linux-gnu/
-COPY --from=builder liboprf/src/noise_xk/lib*.so /usr/lib/x86_64-linux-gnu/
-COPY --from=builder liboprf/src/lib*.so /usr/lib/x86_64-linux-gnu/
+COPY --from=builder liboprf/src/noise_xk/lib*.so /usr/local/lib/
+COPY --from=builder liboprf/src/lib*.so /usr/local/lib/
 RUN ldconfig
 
 COPY --chown=${APP_USER}:${APP_GROUP} --from=builder /usr/local /usr/local


### PR DESCRIPTION
While debuggen/testing we moved the builded oprf lib files to `/usr/local/lib` as this directory is used by both architectures we are currently using. See the below output for references.

This PR fixes the issue that the `liboprf` library could not be found.

When I build and run PRS on my mac 15.0.1 om M1 Max processor I get the following error:
```
2025-10-22 16:43:38.696 | ➡️ Creating the configuration file
2025-10-22 16:43:38.697 | ⚠️ Configuration file already exists. Skipping.
2025-10-22 16:43:38.697 | ➡️ Copying the auth_cert.json file
2025-10-22 16:43:38.699 | ⚠️ auth_cert_json file already exists. Skipping.
2025-10-22 16:43:38.702 | ⚠️ OPRF secret key already exists. Skipping.
2025-10-22 16:43:38.702 | Migrating
2025-10-22 16:43:38.707 | 👀 Checking migrations for postgres on postgres
2025-10-22 16:43:38.791 | ⏩ File sql/001-initial.sql is already in the migrations table. Skipping.
2025-10-22 16:43:38.819 | ⏩ File sql/002-key-entry.sql is already in the migrations table. Skipping.
2025-10-22 16:43:38.846 | ⏩ File sql/003-level.sql is already in the migrations table. Skipping.
2025-10-22 16:43:38.901 | ⏩ File sql/004-org.sql is already in the migrations table. Skipping.
2025-10-22 16:43:38.903 | Start main process
2025-10-22 16:43:40.925 | Traceback (most recent call last):
2025-10-22 16:43:40.925 |   File "<frozen runpy>", line 198, in _run_module_as_main
2025-10-22 16:43:40.925 |   File "<frozen runpy>", line 88, in _run_code
2025-10-22 16:43:40.925 |   File "/src/app/main.py", line 1, in <module>
2025-10-22 16:43:40.925 |     from app import application
2025-10-22 16:43:40.925 |   File "/src/app/application.py", line 9, in <module>
2025-10-22 16:43:40.925 |     from app.routers.health import router as health_router
2025-10-22 16:43:40.925 |   File "/src/app/routers/health.py", line 6, in <module>
2025-10-22 16:43:40.925 |     from app import container
2025-10-22 16:43:40.925 |   File "/src/app/container.py", line 19, in <module>
2025-10-22 16:43:40.925 |     from app.services.oprf.oprf_service import OprfService
2025-10-22 16:43:40.925 |   File "/src/app/services/oprf/oprf_service.py", line 2, in <module>
2025-10-22 16:43:40.925 |     import pyoprf
2025-10-22 16:43:40.925 |   File "/usr/local/lib/python3.11/site-packages/pyoprf/__init__.py", line 41, in <module>
2025-10-22 16:43:40.925 |     raise ValueError('Unable to find liboprf')
2025-10-22 16:43:40.925 | ValueError: Unable to find liboprf
```

Output of `ld --verbose` command on Mac M1 (ARM64 (or AArch64) architecture):
```
GNU ld (GNU Binutils for Debian) 2.44
  Supported emulations:
   aarch64linux
   aarch64elf
   aarch64elf32
   aarch64elf32b
   aarch64elfb
   armelf
   armelfb
   aarch64linuxb
   aarch64linux32
   aarch64linux32b
   armelfb_linux_eabi
   armelf_linux_eabi
using internal linker script:
==================================================
/* Script for -z combreloc */
/* Copyright (C) 2014-2025 Free Software Foundation, Inc.
   Copying and distribution of this script, with or without modification,
   are permitted in any medium without royalty provided the copyright
   notice and this notice are preserved.  */
OUTPUT_FORMAT("elf64-littleaarch64", "elf64-bigaarch64", "elf64-littleaarch64")
OUTPUT_ARCH(aarch64)
ENTRY(_start)
SEARCH_DIR("=/usr/local/lib/aarch64-linux-gnu"); SEARCH_DIR("=/lib/aarch64-linux-gnu"); SEARCH_DIR("=/usr/lib/aarch64-linux-gnu"); SEARCH_DIR("=/usr/local/lib"); SEARCH_DIR("=/lib"); SEARCH_DIR("=/usr/lib"); SEARCH_DIR("=/usr/aarch64-linux-gnu/lib");
SECTIONS
```


Output of `ld --verbose` command on x86_64, amd64 architecture.

```
GNU ld (GNU Binutils for Debian) 2.44
  Supported emulations:
   elf_x86_64
   elf32_x86_64
   elf_i386
   elf_iamcu
   i386pep
   i386pe
using internal linker script:
==================================================
/* Script for -z combreloc -z separate-code */
/* Copyright (C) 2014-2025 Free Software Foundation, Inc.
   Copying and distribution of this script, with or without modification,
   are permitted in any medium without royalty provided the copyright
   notice and this notice are preserved.  */
OUTPUT_FORMAT("elf64-x86-64", "elf64-x86-64", "elf64-x86-64")
OUTPUT_ARCH(i386:x86-64)
ENTRY(_start)
SEARCH_DIR("=/usr/local/lib/x86_64-linux-gnu"); SEARCH_DIR("=/lib/x86_64-linux-gnu"); SEARCH_DIR("=/usr/lib/x86_64-linux-gnu"); SEARCH_DIR("=/usr/lib/x86_64-linux-gnu64"); SEARCH_DIR("=/usr/local/lib64"); SEARCH_DIR("=/lib64"); SEARCH_DIR("=/usr/lib64"); SEARCH_DIR("=/usr/local/lib"); SEARCH_DIR("=/lib"); SEARCH_DIR("=/usr/lib"); SEARCH_DIR("=/usr/x86_64-linux-gnu/lib64"); SEARCH_DIR("=/usr/x86_64-linux-gnu/lib");
```