### PR TITLE
Set the default oprf location for testing purposes

### DIFF
--- a/app.conf.example
+++ b/app.conf.example
@@ -28,7 +28,7 @@ ssl_key_file = server.key
 
 [oprf]
 ; file with base64 server key for oprf evaluation (create with oprf_service.generate_key)
-server_key_file=
+server_key_file=secrets/oprf-server.key
 
 [pseudonym]
 ; Master key for hkdf


### PR DESCRIPTION
Fixes missing a reference to the default oprf key location, generated in the init script when starting (and the key does not exist).