### PR TITLE
Fix CI Docker image scan and adjust upload settings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -247,19 +247,20 @@ jobs:
           severity: "CRITICAL,HIGH"
           vuln-type: "library"
 
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v4
-        # Only upload SARIF results on main branch or version tags
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
-        with:
-          sarif_file: "trivy-results.sarif"
+      # Re-enable if Code security tab upload is enabled by OPS
+      # - name: Upload Trivy scan results to GitHub Security tab
+      #   uses: github/codeql-action/upload-sarif@v4
+      #   # Only upload SARIF results on main branch or version tags
+      #   if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+      #   with:
+      #     sarif_file: "trivy-results.sarif"
 
       - name: Fail build on vulnerabilities
         uses: aquasecurity/trivy-action@0.33.1
         with:
           image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
           format: "table"
-          exit-code: "1"
+          exit-code: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && '0' || '1' }}
           severity: "CRITICAL,HIGH"
           vuln-type: "library"
           skip-setup-trivy: true

--- a/.github/workflows/release-docker.yaml
+++ b/.github/workflows/release-docker.yaml
@@ -77,19 +77,20 @@ jobs:
                 severity: "CRITICAL,HIGH"
                 vuln-type: "library"
 
-            - name: Upload Trivy scan results to GitHub Security tab
-              uses: github/codeql-action/upload-sarif@v4
-              # Only upload SARIF results on main branch or version tags
-              if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
-              with:
-                sarif_file: "trivy-results.sarif"
+            # Re-enable if Code security tab upload is enabled by OPS
+            # - name: Upload Trivy scan results to GitHub Security tab
+            #   uses: github/codeql-action/upload-sarif@v4
+            #   # Only upload SARIF results on main branch or version tags
+            #   if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+            #   with:
+            #     sarif_file: "trivy-results.sarif"
 
             - name: Fail on vulnerabilities
               uses: aquasecurity/trivy-action@0.33.1
               with:
                 image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
                 format: "table"
-                exit-code: "1"
+                exit-code: "0"
                 severity: "CRITICAL,HIGH"
                 vuln-type: "library"
                 skip-setup-trivy: true


### PR DESCRIPTION
Github Security scanning is disabled. Needs to be Enabled by OPS. 
This PR comments out the upload part that fails because it is disabled and also the following:
 - when vulnerabilities exist, fail CI on PR but dont block creating docker images on merge to main or on tags