### PR TITLE
Seperate venv location in docker container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,8 +6,6 @@ services:
         NEW_UID: ${NEW_UID:-1000}
         NEW_GID: ${NEW_GID:-1000}
       dockerfile: docker/Dockerfile
-    environment:
-        FASTAPI_CONFIG_PATH: /src/app.conf
     volumes:
       - ./:/src
       - ./secrets:/usr/local/secrets
@@ -44,10 +42,8 @@ services:
     ports:
       - 5432:5432
     volumes:
-      - './docker/create-testing-database.sql:/docker-entrypoint-initdb.d/10-create-testing-database.sql'
+      - ./docker/create-testing-database.sql:/docker-entrypoint-initdb.d/10-create-testing-database.sql
+      - postgres_data:/var/lib/postgresql/data
 
 volumes:
-  secrets:
-    name: secrets
-  pgdata:
-    name: pgdata
+  postgres_data:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -81,8 +81,12 @@ COPY --from=builder /liboprf/src/noise_xk/lib*.so /usr/local/lib/
 COPY --from=builder /liboprf/src/lib*.so /usr/local/lib/
 RUN ldconfig
 
+# Set different virtualenv path for runtime to avoid issues when mounting source code
+ENV VIRTUAL_ENV="/opt/app/docker-venv"
+ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
+
 # Copy only the virtualenv — no pip, no poetry, no build tools
-COPY --from=builder --chown=${APP_USER}:${APP_GROUP} /src/.venv /src/.venv
+COPY --from=builder --chown=${APP_USER}:${APP_GROUP} /src/.venv ${VIRTUAL_ENV}
 
 # Copy only what the app needs at runtime (no tests, docs, CI artifacts, etc.)
 COPY --chown=${APP_USER}:${APP_GROUP} app/ /src/app/
@@ -111,9 +115,5 @@ USER ${APP_USER}
 
 EXPOSE 6502
 WORKDIR ${PROJECT_DIR}
-
-ENV PYTHONPATH=${PROJECT_DIR} \
-    VIRTUAL_ENV=/src/.venv \
-    PATH="/src/.venv/bin:$PATH"
 
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
The `/src` folder is mounted in the docker container, this overrides the `/src` folder inside the container and does not have a `.venv` anymore if you don't have a `.venv` locally.

Also fixes that the data of the database is stored in a volume.