### PR TITLE
Add config and secrets directory in docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -87,12 +87,14 @@ ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 
 # Copy only the virtualenv — no pip, no poetry, no build tools
 COPY --from=builder --chown=${APP_USER}:${APP_GROUP} /src/.venv ${VIRTUAL_ENV}
+RUN mkdir /opt/app/config && chown ${APP_USER}:${APP_GROUP} /opt/app/config
 
 # Copy only what the app needs at runtime (no tests, docs, CI artifacts, etc.)
 COPY --chown=${APP_USER}:${APP_GROUP} app/ /src/app/
 COPY --chown=${APP_USER}:${APP_GROUP} sql/ /src/sql/
 COPY --chown=${APP_USER}:${APP_GROUP} tools/ /src/tools/
 COPY --chown=${APP_USER}:${APP_GROUP} app.conf.example /src/
+RUN mkdir /src/secrets && chown ${APP_USER}:${APP_GROUP} /src/secrets
 
 # version.json is generated from build args so CI workspace artifacts never leak in
 ARG RELEASE_VERSION=dev


### PR DESCRIPTION
Needed because app runs as (non-root) app user.

Need to discuss what we want.
Other options:
- Use a mounted directory to store config in, that is also possible but not tightly coupled with the running stack and other secrets in volumes.
- Or create every config before starting containers in coordination setup.