### PR TITLE
Fix missing padding of encryptedPersonalId

### DIFF
--- a/app/models/requests.py
+++ b/app/models/requests.py
@@ -1,3 +1,4 @@
+import base64
 import logging
 from typing import Any, Literal, List
 
@@ -32,6 +33,23 @@ class RidReceiveRequest(BaseModel):
     recipientOrganization: str
     recipientScope: str
     pseudonymType: Literal["rp", "irp", "bsn"]
+
+
+class BlindRequest(BaseModel):
+    encryptedPersonalId: str = Field(..., min_length=2)
+    recipientOrganization: str = Field(..., min_length=2)
+    recipientScope: str = Field(..., min_length=2)
+
+    @field_validator("encryptedPersonalId")
+    def validate_base64(cls, v: str) -> str:
+        try:
+            pad = "=" * ((4 - len(v) % 4) % 4)
+            normalized = v + pad
+            base64.urlsafe_b64decode(normalized)
+        except Exception as e:
+            raise ValueError(f"must be base64url: {e}")
+
+        return normalized
 
 
 class RidExchangeRequest(BaseModel):

--- a/app/routers/oprf.py
+++ b/app/routers/oprf.py
@@ -4,8 +4,9 @@ from fastapi import APIRouter, Depends
 from starlette.responses import JSONResponse
 
 from app import container
+from app.models.requests import BlindRequest
 from app.services.key_resolver import KeyResolver
-from app.services.oprf.oprf_service import BlindRequest, OprfService
+from app.services.oprf.oprf_service import OprfService
 from app.services.org_service import OrgService
 
 logger = logging.getLogger(__name__)

--- a/app/services/oprf/oprf_service.py
+++ b/app/services/oprf/oprf_service.py
@@ -1,29 +1,12 @@
 import base64
 import pyoprf
 from jwcrypto import jwk
-from pydantic import BaseModel, Field, field_validator
 
 from app.services.oprf.jwe_token import BlindJwe
+from app.models.requests import BlindRequest
 import logging
 
 logger = logging.getLogger(__name__)
-
-
-class BlindRequest(BaseModel):
-    encryptedPersonalId: str = Field(..., min_length=2)
-    recipientOrganization: str = Field(..., min_length=2)
-    recipientScope: str = Field(..., min_length=2)
-
-    @field_validator("encryptedPersonalId")
-    def validate_base64(cls, v: str) -> str:
-        try:
-            pad = "=" * ((4 - len(v) % 4) % 4)
-            base64.urlsafe_b64decode(v + pad)
-        except Exception as e:
-            logger.error("invalid base64url string: %r", v)
-            raise ValueError(f"must be base64url: {e}")
-
-        return v
 
 
 class OprfService:

--- a/oprf/models.py
+++ b/oprf/models.py
@@ -24,8 +24,9 @@ class BlindRequest(BaseModel):
     def validate_base64(cls, v: str) -> str:
         try:
             pad = "=" * ((4 - len(v) % 4) % 4)
-            base64.urlsafe_b64decode(v +pad)
+            normalized = v + pad
+            base64.urlsafe_b64decode(normalized)
         except Exception as e:
             raise ValueError(f"must be base64url: {e}")
 
-        return v
+        return normalized

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1,0 +1,24 @@
+from app.models.requests import BlindRequest
+from pydantic import ValidationError
+
+
+def test_blind_request_encrypted_personal_id_is_normalized() -> None:
+    request = BlindRequest(
+        encryptedPersonalId="YQ",
+        recipientOrganization="ura:12345678",
+        recipientScope="nvi",
+    )
+
+    assert request.encryptedPersonalId == "YQ=="
+
+
+def test_blind_request_encrypted_personal_id_invalid_base64url() -> None:
+    try:
+        BlindRequest(
+            encryptedPersonalId="a?",
+            recipientOrganization="ura:12345678",
+            recipientScope="nvi",
+        )
+        assert False, "Expected ValidationError for invalid base64url"
+    except ValidationError as e:
+        assert "must be base64url" in str(e)


### PR DESCRIPTION
The encryptedPersonalId was validated with the added padding but later when used it tries to decode it and then throws exception becasue of the missing padding.

Now the padding is added in de BlindRequest model.

Fixes:

```
│ ERROR:app.services.oprf.oprf_service:unable to evaluate blind: Incorrect padding                                                                                                                              │
│ ERROR:app.routers.oprf:unable to evaluate blind: ValueError('unable to evaluate blind: Incorrect padding')                                                                                                    │
│ Traceback (most recent call last):                                                                                                                                                                            │
│   File "/src/app/services/oprf/oprf_service.py", line 45, in eval_blind                                                                                                                                       │
│     bi = base64.urlsafe_b64decode(req.encryptedPersonalId)                                                                                                                                                    │
│   File "/usr/local/lib/python3.14/base64.py", line 131, in urlsafe_b64decode                                                                                                                                  │
│     return b64decode(s)                                                                                                                                                                                       │
│   File "/usr/local/lib/python3.14/base64.py", line 85, in b64decode                                                                                                                                           │
│     return binascii.a2b_base64(s, strict_mode=validate)                                                                                                                                                       │
│            ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                       │
│ binascii.Error: Incorrect padding                                                                                                                                                                             │
│                                                                                                                                                                                                               │
│ During handling of the above exception, another exception occurred:                                                                                                                                           │
│                                                                                                                                                                                                               │
│ Traceback (most recent call last):                                                                                                                                                                            │
│   File "/src/app/routers/oprf.py", line 39, in post_eval                                                                                                                                                      │
│     jwe_str = oprf_service.eval_blind(req, pub_key_jwk)                                                                                                                                                       │
│   File "/src/app/services/oprf/oprf_service.py", line 49, in eval_blind                                                                                                                                       │
│     raise ValueError(f"unable to evaluate blind: {e}")                                                                                                                                                        │
│ ValueError: unable to evaluate blind: Incorrect padding                                                                                                                                                       │
│ INFO:     IP:45602 - "POST /oprf/eval HTTP/1.1" 400 Bad Request  
```