### PR TITLE
fix: proper error status code on invalid auth headers

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -1,6 +1,6 @@
 import logging
 
-from fastapi import Depends
+from fastapi import Depends, HTTPException
 from starlette.requests import Request
 
 from app import container
@@ -32,8 +32,8 @@ def get_auth_ctx(
     try:
         auth_headers = AuthHeaders.from_request(request)
     except ValueError as e:
-        logger.exception("Failed to extract AuthHeaders")
-        raise ValueError(f"Inavalid Authorization Headers in request: {e}")
+        logger.exception(f"Inavalid Authorization Headers in request: {e}")
+        raise HTTPException(status_code=403, detail="Unauthorized request")
 
     validated_auth_headers = auth_headers_service.validate(auth_headers)
     claims = AuthenticationClaims(


### PR DESCRIPTION
changed response code from Internal Server Error to unauthorised when auth header validation fails