### PR TITLE
Refactor to use OinType

### DIFF
--- a/app/db/entities/hsm_key_versions.py
+++ b/app/db/entities/hsm_key_versions.py
@@ -38,7 +38,7 @@ class HsmKeyVersion(Base):
 
     @property
     def oin(self) -> str:
-        return self.organization.oin
+        return str(self.organization.oin)
 
     def to_dict(self) -> dict[str, Any]:
         return {

--- a/app/db/entities/hsm_key_versions.py
+++ b/app/db/entities/hsm_key_versions.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.entities.base import Base
 from app.db.entities.organization import Organization
+from app.models.oin import Oin
 
 
 class HsmKeyVersion(Base):
@@ -37,8 +38,8 @@ class HsmKeyVersion(Base):
     organization: Mapped[Organization] = relationship("Organization")
 
     @property
-    def oin(self) -> str:
-        return self.organization.oin.value
+    def oin(self) -> Oin:
+        return self.organization.oin
 
     def to_dict(self) -> dict[str, Any]:
         return {

--- a/app/db/entities/hsm_key_versions.py
+++ b/app/db/entities/hsm_key_versions.py
@@ -38,12 +38,12 @@ class HsmKeyVersion(Base):
 
     @property
     def oin(self) -> str:
-        return str(self.organization.oin)
+        return self.organization.oin.value
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "id": str(self.id),
-            "oin": self.oin,
+            "oin": self.oin.value,
             "version": self.version,
             "from_dt": self.from_dt,
             "until_dt": self.until_dt,

--- a/app/db/entities/organization.py
+++ b/app/db/entities/organization.py
@@ -1,6 +1,8 @@
 import uuid
 from typing import Any, List, TYPE_CHECKING, Optional
 
+from app.db.types.oin import OinType
+from app.models.oin import Oin
 from sqlalchemy import String
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -21,7 +23,7 @@ class Organization(Base):
     id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
     )
-    oin: Mapped[str] = mapped_column("oin", String, unique=True)
+    oin: Mapped[Oin] = mapped_column("oin", OinType(), unique=True)
     name: Mapped[str] = mapped_column("name", String)
     max_rid_usage: Mapped[str] = mapped_column("max_rid_usage", String)
 
@@ -33,7 +35,7 @@ class Organization(Base):
 
     def to_dict(self) -> dict[str, Any]:
         return {
-            "oin": self.oin,
+            "oin": str(self.oin),
             "name": self.name,
             "max_rid_usage": self.max_rid_usage,
         }

--- a/app/db/entities/organization.py
+++ b/app/db/entities/organization.py
@@ -35,7 +35,7 @@ class Organization(Base):
 
     def to_dict(self) -> dict[str, Any]:
         return {
-            "oin": str(self.oin),
+            "oin": self.oin.value,
             "name": self.name,
             "max_rid_usage": self.max_rid_usage,
         }

--- a/app/db/repositories/hsm_key_version_repository.py
+++ b/app/db/repositories/hsm_key_version_repository.py
@@ -36,7 +36,7 @@ class HsmKeyVersionRepository(RepositoryBase):
             )
         )
         if oin is not None:
-            query = query.join(Organization).where(Organization.oin == oin.value)
+            query = query.join(Organization).where(Organization.oin == oin)
         return self.db_session.execute(query).scalars().all()
 
     def get_by_oin(self, oin: Oin) -> Sequence[HsmKeyVersion]:
@@ -48,7 +48,7 @@ class HsmKeyVersionRepository(RepositoryBase):
             select(HsmKeyVersion)
             .options(joinedload(HsmKeyVersion.organization))
             .join(Organization)
-            .where(Organization.oin == oin.value)
+            .where(Organization.oin == oin)
             .order_by(HsmKeyVersion.version)
         )
         return self.db_session.execute(query).scalars().all()

--- a/app/db/repositories/org_repository.py
+++ b/app/db/repositories/org_repository.py
@@ -7,19 +7,21 @@ from app.db.entities.organization import Organization
 from app.db.repositories.repository_base import RepositoryBase
 from sqlalchemy import select
 
+from app.models.oin import Oin
+
 logger = logging.getLogger(__name__)
 
 
 @repository(Organization)
 class OrgRepository(RepositoryBase):
-    def get_by_oin(self, oin: str) -> Optional[Organization]:
+    def get_by_oin(self, oin: Oin) -> Optional[Organization]:
         """
         Fetches the organization by its unique ID.
         """
         query = select(Organization).where(Organization.oin == oin)
         return self.db_session.execute(query).scalars().first()
 
-    def create(self, oin: str, name: str, max_usage_level: str) -> Organization:
+    def create(self, oin: Oin, name: str, max_usage_level: str) -> Organization:
         """
         Creates a new org entry.
         """
@@ -31,7 +33,7 @@ class OrgRepository(RepositoryBase):
         self.db_session.add(entry)
         self.db_session.flush()
 
-        logger.info("created organization with OIN %s and name %r", oin, name)
+        logger.info("created organization with OIN %s and name %r", oin.value, name)
         return entry
 
     def update(

--- a/app/db/types/oin.py
+++ b/app/db/types/oin.py
@@ -1,0 +1,29 @@
+from typing import Any
+
+from sqlalchemy import String
+from sqlalchemy.types import TypeDecorator
+
+from app.models.oin import Oin
+
+
+class OinType(TypeDecorator[Oin]):
+    """Map ``Organization.oin`` to the OIN value object and store it as text."""
+
+    impl = String
+    cache_ok = True
+    python_type = Oin
+
+    def process_bind_param(self, value: Any, _dialect: Any) -> str | None:
+        if value is None:
+            return None
+
+        if isinstance(value, Oin):
+            return value.value
+
+        return str(value)
+
+    def process_result_value(self, value: Any, _dialect: Any) -> Oin | None:
+        if value is None:
+            return None
+
+        return Oin(value)

--- a/app/models/oin.py
+++ b/app/models/oin.py
@@ -92,6 +92,8 @@ class Oin:
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, Oin):
             return self.value == other.value
+        if isinstance(other, str):
+            return self.value == other
         return False
 
     def __hash__(self) -> int:

--- a/app/models/oin.py
+++ b/app/models/oin.py
@@ -3,11 +3,18 @@ from typing import Any
 
 from pydantic import GetCoreSchemaHandler
 from pydantic.json_schema import JsonSchemaValue
-from pydantic_core import core_schema
+from pydantic_core import PydanticCustomError, core_schema
 
 # An OIN is always 20 characters:
 #   prefix (8 digits) + mainnumber (8 or 9 alphanumeric) + suffix (4 or 3 zeros)
 OIN_PATTERN = re.compile(r"^\d{8}(?:[A-Za-z0-9]{8}0{4}|[A-Za-z0-9]{9}0{3})$")
+RECIPIENT_ORGANIZATION_PREFIX = "oin:"
+_RECIPIENT_ORGANIZATION_SUFFIX_PATTERN = (
+    r"\d{8}(?:[A-Za-z0-9]{8}0{4}|[A-Za-z0-9]{9}0{3})"
+)
+RECIPIENT_ORGANIZATION_PATTERN = re.compile(
+    rf"^{RECIPIENT_ORGANIZATION_PREFIX}{_RECIPIENT_ORGANIZATION_SUFFIX_PATTERN}$"
+)
 
 
 class Oin:
@@ -130,3 +137,75 @@ class Oin:
                 "8-digit prefix + 8/9-character alphanumeric mainnumber + 4/3 trailing zeros (suffix)."
             ),
         }
+
+
+class RecipientOrganizationOin(Oin):
+    """An OIN supplied with recipient organization prefix, e.g. ``oin:<oin>``.
+
+    Internally the stored value remains a plain OIN without the ``oin:`` prefix.
+    """
+
+    PREFIX = RECIPIENT_ORGANIZATION_PREFIX
+    _INVALID_ERROR = "Invalid recipient organization. Format: oin:<oin_number>"
+
+    def __init__(self, value: Any) -> None:
+        if isinstance(value, str) and value.startswith(self.PREFIX):
+            value = value[len(self.PREFIX) :]
+        super().__init__(value)
+
+    @classmethod
+    def _pydantic_validate(cls, value: Any) -> "RecipientOrganizationOin":
+        if isinstance(value, cls):
+            return value
+
+        if isinstance(value, Oin):
+            return cls(value.value)
+
+        if not isinstance(value, str):
+            raise PydanticCustomError(
+                "invalid_recipient_organization", cls._INVALID_ERROR
+            )
+
+        if not value.startswith(cls.PREFIX):
+            raise PydanticCustomError(
+                "invalid_recipient_organization", cls._INVALID_ERROR
+            )
+
+        try:
+            return cls(value[len(cls.PREFIX) :])
+        except ValueError as e:
+            raise PydanticCustomError(
+                "invalid_recipient_organization", "{error}", {"error": str(e)}
+            ) from e
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, _source_type: Any, _handler: GetCoreSchemaHandler
+    ) -> core_schema.CoreSchema:
+        return core_schema.no_info_plain_validator_function(
+            cls._pydantic_validate,
+            serialization=core_schema.to_string_ser_schema(),
+        )
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls, _schema: core_schema.CoreSchema, _handler: Any
+    ) -> JsonSchemaValue:
+        return {
+            "type": "string",
+            "pattern": RECIPIENT_ORGANIZATION_PATTERN.pattern,
+            "examples": [f"{RECIPIENT_ORGANIZATION_PREFIX}00000099000000001000"],
+            "description": (
+                "Recipient organization string: prefix followed by an OIN (20-char "
+                "identifier)."
+            ),
+        }
+
+    def __str__(self) -> str:
+        """Return the recipient organization OIN in external format, including ``oin:``."""
+        return f"{self.PREFIX}{self.value}"
+
+    @property
+    def value(self) -> str:
+        """Return the normalized OIN value without the ``oin:`` prefix."""
+        return super().value

--- a/app/models/requests.py
+++ b/app/models/requests.py
@@ -5,7 +5,7 @@ from typing import Any, Literal, List
 
 from pydantic import BaseModel, ConfigDict, model_validator, Field, field_validator
 
-from app.models.oin import Oin
+from app.models.oin import Oin, RecipientOrganizationOin
 from app.personal_id import PersonalId
 from app.services.pseudonym_service import PseudonymType
 from app.rid import RidUsage
@@ -37,14 +37,14 @@ class HsmKeyVersionUpdateRequest(BaseModel):
 
 class RidReceiveRequest(BaseModel):
     rid: str
-    recipientOrganization: str
+    recipientOrganization: RecipientOrganizationOin
     recipientScope: str
     pseudonymType: Literal["rp", "irp", "bsn"]
 
 
 class BlindRequest(BaseModel):
     encryptedPersonalId: str = Field(..., min_length=2)
-    recipientOrganization: str = Field(..., min_length=2)
+    recipientOrganization: RecipientOrganizationOin
     recipientScope: str = Field(..., min_length=2)
 
     @field_validator("encryptedPersonalId")
@@ -61,7 +61,7 @@ class BlindRequest(BaseModel):
 
 class RidExchangeRequest(BaseModel):
     personalId: Any
-    recipientOrganization: str
+    recipientOrganization: RecipientOrganizationOin
     recipientScope: str
     ridUsage: Any
 
@@ -90,7 +90,7 @@ class ExchangeRequest(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     personalId: Any
-    recipientOrganization: str
+    recipientOrganization: RecipientOrganizationOin
     recipientScope: str = Field(..., min_length=1, max_length=100)
     pseudonymType: PseudonymType
 

--- a/app/models/requests.py
+++ b/app/models/requests.py
@@ -11,7 +11,6 @@ from app.services.pseudonym_service import PseudonymType
 from app.rid import RidUsage
 
 logger = logging.getLogger(__name__)
-OIN_PATTERN = r"^\d{8}(?:[A-Za-z0-9]{8}0{4}|[A-Za-z0-9]{9}0{3})$"
 
 
 class RegisterRequest(BaseModel):

--- a/app/models/requests.py
+++ b/app/models/requests.py
@@ -1,7 +1,7 @@
 import base64
 import logging
 from datetime import datetime
-from typing import Any, Literal, List, Optional
+from typing import Any, Literal, List
 
 from pydantic import BaseModel, ConfigDict, model_validator, Field, field_validator
 
@@ -15,27 +15,19 @@ logger = logging.getLogger(__name__)
 
 class RegisterRequest(BaseModel):
     scope: List[str]
-    key_id: Optional[str]
+    key_id: str | None
 
 
 class OrgRequest(BaseModel):
-    oin: str
+    oin: Oin
     name: str = Field(..., min_length=5, max_length=50)
     max_key_usage: RidUsage
 
-    @field_validator("oin")
-    def validate_oin(cls, v: Any) -> str:
-        return str(Oin(v))
-
 
 class HsmKeyVersionRequest(BaseModel):
-    oin: str
+    oin: Oin
     from_dt: datetime | None = None
     until_dt: datetime | None = None
-
-    @field_validator("oin")
-    def validate_oin(cls, v: Any) -> str:
-        return str(Oin(v))
 
 
 class HsmKeyVersionUpdateRequest(BaseModel):

--- a/app/routers/exchange.py
+++ b/app/routers/exchange.py
@@ -7,6 +7,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 
 from app import container
+from app.models.oin import Oin
 from app.models.requests import ExchangeRequest, RidExchangeRequest, RidReceiveRequest
 from app.personal_id import PersonalId
 from app.rid import ALLOWED_BY_RID_USAGE, REQUIRED_MIN_USAGE, USAGE_RANK, RidUsage
@@ -21,8 +22,15 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+def _parse_prefixed_oin(oin: str) -> Oin:
+    if not oin.startswith("oin:"):
+        logger.warning("recipientOrganization does not start with 'oin:': %s", oin)
+        raise InvalidOin(oin)
+    return Oin(oin[4:])
+
+
 class OrganizationNotFound(HTTPException):
-    def __init__(self, oin: str) -> None:
+    def __init__(self, oin: Oin) -> None:
         super().__init__(
             status_code=404, detail=f"Organization with OIN '{oin}' not found"
         )
@@ -42,7 +50,7 @@ class InvalidOin(HTTPException):
 
 
 class PubKeyNotFound(HTTPException):
-    def __init__(self, oin: str, scope: str) -> None:
+    def __init__(self, oin: Oin, scope: str) -> None:
         super().__init__(
             status_code=404,
             detail=f"No public key found for organization '{oin}' and scope '{scope}'",
@@ -110,11 +118,7 @@ def receive(
         )
         raise InvalidRID(message="Requested pseudonym type not allowed by RID usage")
 
-    if not req.recipientOrganization.startswith("oin:"):
-        logger.warning("does not start with 'oin:': %s", req.recipientOrganization)
-        raise InvalidOin(req.recipientOrganization)
-
-    oin = req.recipientOrganization[4:]
+    oin = _parse_prefixed_oin(req.recipientOrganization)
 
     max_rid_usage = key_resolver.max_rid_usage(oin)
     if max_rid_usage is None:
@@ -205,9 +209,7 @@ def exchange_rid(
     rid_str = json.dumps(rid_data)
     rid = rid_service.encrypt_rid(rid_str)
 
-    if not req.recipientOrganization.startswith("oin:"):
-        raise InvalidOin(req.recipientOrganization)
-    oin = req.recipientOrganization[4:]
+    oin = _parse_prefixed_oin(req.recipientOrganization)
 
     org = org_service.get_by_oin(oin)
     if org is None:
@@ -249,24 +251,19 @@ def exchange_pseudonym(
     org_service: OrgService = Depends(container.get_org_service),
     mtls_service: MtlsService = Depends(container.get_mtls_service),
 ) -> Response:
-    if not req.recipientOrganization.startswith("oin:"):
-        logger.warning("OIN does not start with 'oin:': %s", req.recipientOrganization)
-        raise InvalidOin(req.recipientOrganization)
-    recipient_organization = req.recipientOrganization[4:]
+    recipient_oin = _parse_prefixed_oin(req.recipientOrganization)
 
-    org = org_service.get_by_oin(recipient_organization)
+    org = org_service.get_by_oin(recipient_oin)
     if org is None:
-        logger.warning(
-            "recipient organization not found for OIN: %s", recipient_organization
-        )
-        raise OrganizationNotFound(recipient_organization)
+        logger.warning("recipient organization not found for OIN: %s", recipient_oin)
+        raise OrganizationNotFound(recipient_oin)
 
     source_org = mtls_service.get_org_from_request(request)
 
     if req.pseudonymType == PseudonymType.Irreversible:
         res = pseudonym_service.generate_irreversible_pseudonym(
             personal_id=req.personalId,
-            recipient_organization=recipient_organization,
+            recipient_organization=str(recipient_oin),
             recipient_scope=req.recipientScope,
         )
         subject = "pseudonym:irreversible:" + res
@@ -283,7 +280,7 @@ def exchange_pseudonym(
 
         res = pseudonym_service.generate_reversible_pseudonym(
             personal_id=req.personalId,
-            recipient_organization=recipient_organization,
+            recipient_organization=str(recipient_oin),
             recipient_scope=req.recipientScope,
         )
         subject = "pseudonym:reversible:" + res
@@ -294,7 +291,7 @@ def exchange_pseudonym(
     if subject is None:
         logger.error(
             "pseudonym generation failed for recipient_organization: %s, recipient_scope: %s, pseudonym_type: %s",
-            recipient_organization,
+            recipient_oin,
             req.recipientScope,
             req.pseudonymType,
         )
@@ -304,13 +301,13 @@ def exchange_pseudonym(
     if pub_key_jwk is None:
         logger.warning(
             "no public key found for organization '%s' and scope '%s'",
-            recipient_organization,
+            recipient_oin,
             req.recipientScope,
         )
-        raise PubKeyNotFound(str(org.oin), req.recipientScope)
+        raise PubKeyNotFound(org.oin, req.recipientScope)
 
     jwe = BlindJwe.build(
-        audience=recipient_organization,
+        audience=str(recipient_oin),
         scope=req.recipientScope,
         subject=subject,
         pub_key=pub_key_jwk,

--- a/app/routers/exchange.py
+++ b/app/routers/exchange.py
@@ -22,17 +22,10 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-def _parse_prefixed_oin(oin: str) -> Oin:
-    if not oin.startswith("oin:"):
-        logger.warning("recipientOrganization does not start with 'oin:': %s", oin)
-        raise InvalidOin(oin)
-    return Oin(oin[4:])
-
-
 class OrganizationNotFound(HTTPException):
     def __init__(self, oin: Oin) -> None:
         super().__init__(
-            status_code=404, detail=f"Organization with OIN '{oin}' not found"
+            status_code=404, detail=f"Organization with OIN '{oin.value}' not found"
         )
 
 
@@ -41,19 +34,11 @@ class InvalidRID(HTTPException):
         super().__init__(status_code=400, detail=message)
 
 
-class InvalidOin(HTTPException):
-    def __init__(self, oin: str) -> None:
-        super().__init__(
-            status_code=400,
-            detail=f"Invalid organization OIN '{oin}'. Must start with 'oin:'",
-        )
-
-
 class PubKeyNotFound(HTTPException):
     def __init__(self, oin: Oin, scope: str) -> None:
         super().__init__(
             status_code=404,
-            detail=f"No public key found for organization '{oin}' and scope '{scope}'",
+            detail=f"No public key found for organization '{oin.value}' and scope '{scope}'",
         )
 
 
@@ -93,7 +78,7 @@ def receive(
 
     # Make sure the recipient org/scope matches what is in the RID
     if (
-        recipient_org != req.recipientOrganization
+        recipient_org != str(req.recipientOrganization)
         or recipient_scope != req.recipientScope
     ):
         logger.warning(
@@ -118,7 +103,7 @@ def receive(
         )
         raise InvalidRID(message="Requested pseudonym type not allowed by RID usage")
 
-    oin = _parse_prefixed_oin(req.recipientOrganization)
+    oin = req.recipientOrganization
 
     max_rid_usage = key_resolver.max_rid_usage(oin)
     if max_rid_usage is None:
@@ -202,14 +187,14 @@ def exchange_rid(
         "usage": str(
             req.ridUsage
         ),  # Maximum usage allowed for this RID (capped by the recipient org/scope)
-        "recipient_organization": req.recipientOrganization,
+        "recipient_organization": str(req.recipientOrganization),
         "recipient_scope": req.recipientScope,
         "personal_id": req.personalId.as_str(),
     }
     rid_str = json.dumps(rid_data)
     rid = rid_service.encrypt_rid(rid_str)
 
-    oin = _parse_prefixed_oin(req.recipientOrganization)
+    oin = req.recipientOrganization
 
     org = org_service.get_by_oin(oin)
     if org is None:
@@ -219,14 +204,14 @@ def exchange_rid(
     if pub_key_jwk is None:
         logger.warning(
             "no public key found for organization '%s' and scope '%s'",
-            oin,
+            oin.value,
             req.recipientScope,
         )
         raise PubKeyNotFound(oin, req.recipientScope)
 
     # Create a blind JWE token containing the RID
     jwe = BlindJwe.build(
-        audience=req.recipientOrganization,
+        audience=str(req.recipientOrganization),
         scope=req.recipientScope,
         subject=f"rid:{rid}",
         pub_key=pub_key_jwk,
@@ -251,7 +236,7 @@ def exchange_pseudonym(
     org_service: OrgService = Depends(container.get_org_service),
     mtls_service: MtlsService = Depends(container.get_mtls_service),
 ) -> Response:
-    recipient_oin = _parse_prefixed_oin(req.recipientOrganization)
+    recipient_oin = req.recipientOrganization
 
     org = org_service.get_by_oin(recipient_oin)
     if org is None:

--- a/app/routers/hsm_key_version.py
+++ b/app/routers/hsm_key_version.py
@@ -1,15 +1,13 @@
 import logging
-from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Path
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.encoders import jsonable_encoder
 from starlette.responses import JSONResponse
 
 from app import container
 from app.models.oin import Oin
 from app.models.requests import (
-    OIN_PATTERN,
     HsmKeyVersionRequest,
     HsmKeyVersionUpdateRequest,
 )
@@ -57,7 +55,7 @@ def list_key_versions(
     ),
     org_service: OrgService = Depends(container.get_org_service),
 ) -> JSONResponse:
-    org = org_service.get_by_oin(oin.value)
+    org = org_service.get_by_oin(oin)
     if org is None:
         logger.warning("organization for OIN %r not found", oin.value)
         raise HTTPException(status_code=404, detail="organization not found")

--- a/app/routers/key.py
+++ b/app/routers/key.py
@@ -61,7 +61,7 @@ def list_keys_for_org(
     oin: Oin,
     org_service: OrgService = Depends(container.get_org_service),
 ) -> JSONResponse:
-    org = org_service.get_by_oin(oin.value)
+    org = org_service.get_by_oin(oin)
     if org is None:
         logger.warning("organization for OIN %r not found", oin)
         raise HTTPException(

--- a/app/routers/oprf.py
+++ b/app/routers/oprf.py
@@ -4,7 +4,6 @@ from fastapi import APIRouter, Depends
 from starlette.responses import JSONResponse
 
 from app import container
-from app.models.oin import Oin
 from app.models.requests import BlindRequest
 from app.services.key_resolver import KeyResolver
 from app.services.oprf.oprf_service import OprfService
@@ -25,14 +24,7 @@ def post_eval(
     org_service: OrgService = Depends(container.get_org_service),
     oprf_service: OprfService = Depends(container.get_oprf_service),
 ) -> JSONResponse:
-    if not req.recipientOrganization.startswith("oin:"):
-        logger.warning("does not start with oin: %s" % req.recipientOrganization)
-        return JSONResponse(
-            {"error": "Invalid recipient organization. Format: oin:<oin_number>"},
-            status_code=400,
-        )
-    oin = Oin(req.recipientOrganization[4:])
-
+    oin = req.recipientOrganization
     org = org_service.get_by_oin(oin)
     if org is None:
         logger.warning("no organization found for OIN %r", oin)

--- a/app/routers/oprf.py
+++ b/app/routers/oprf.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends
 from starlette.responses import JSONResponse
 
 from app import container
+from app.models.oin import Oin
 from app.models.requests import BlindRequest
 from app.services.key_resolver import KeyResolver
 from app.services.oprf.oprf_service import OprfService
@@ -30,7 +31,7 @@ def post_eval(
             {"error": "Invalid recipient organization. Format: oin:<oin_number>"},
             status_code=400,
         )
-    oin = req.recipientOrganization[4:]
+    oin = Oin(req.recipientOrganization[4:])
 
     org = org_service.get_by_oin(oin)
     if org is None:

--- a/app/routers/org.py
+++ b/app/routers/org.py
@@ -42,7 +42,7 @@ def list_keys_for_org(
     oin: Oin,
     org_service: OrgService = Depends(container.get_org_service),
 ) -> JSONResponse:
-    org = org_service.get_by_oin(oin.value)
+    org = org_service.get_by_oin(oin)
     if org is None:
         logger.warning("organization for OIN %s not found", oin)
         raise HTTPException(status_code=404, detail="organization not found")
@@ -59,7 +59,7 @@ def put_org(
     org_service: OrgService = Depends(container.get_org_service),
 ) -> JSONResponse:
 
-    org = org_service.get_by_oin(oin.value)
+    org = org_service.get_by_oin(oin)
     if org is None:
         logger.warning("organization for OIN %s not found", oin)
         raise HTTPException(status_code=404, detail="organization not found")
@@ -71,7 +71,7 @@ def put_org(
     org_service.update(
         org.id, req.name, req.max_key_usage or RidUsage.IrreversiblePseudonym
     )
-    updated_entry = org_service.get_by_oin(oin.value)
+    updated_entry = org_service.get_by_oin(oin)
     if updated_entry is None:
         logger.error("failed to retrieve updated org for OIN %s", oin)
         raise HTTPException(status_code=500, detail="failed to retrieve updated org")
@@ -88,7 +88,7 @@ def delete_org(
     key_resolver: KeyResolver = Depends(container.get_key_resolver),
 ) -> JSONResponse:
 
-    org = org_service.get_by_oin(oin.value)
+    org = org_service.get_by_oin(oin)
     if org is None:
         logger.warning(
             "organization not found for delete request, requested_oin=%s", oin

--- a/app/services/hsm_key_cleanup_service.py
+++ b/app/services/hsm_key_cleanup_service.py
@@ -3,7 +3,6 @@ import logging
 import requests
 
 from app.config import ConfigOprf
-from app.models.oin import Oin
 from app.services.hsm_key_version_service import HsmKeyVersionService
 from app.services.oprf.oprf_service import HsmKeyLabel
 
@@ -39,7 +38,7 @@ class HsmKeyCleanupService:
         cleaned = 0
         for version in expired:
             try:
-                label = HsmKeyLabel(Oin(version.oin), version.version)
+                label = HsmKeyLabel(version.oin, version.version)
             except ValueError:
                 logger.exception("Value %r is not a correct OIN number", version.oin)
                 continue

--- a/app/services/hsm_key_version_service.py
+++ b/app/services/hsm_key_version_service.py
@@ -22,7 +22,7 @@ class HsmKeyVersionService:
         self.__db = db
 
     def get_active_versions(
-        self, at: datetime | None = None, oin: Oin|None = None
+        self, at: datetime | None = None, oin: Oin | None = None
     ) -> Sequence[HsmKeyVersion]:
         """
         Returns all key versions that are active at the given moment (defaults to
@@ -57,7 +57,7 @@ class HsmKeyVersionService:
 
     def create_version(
         self,
-        oin: str,
+        oin: Oin,
         from_dt: datetime | None = None,
         until_dt: datetime | None = None,
     ) -> HsmKeyVersion:

--- a/app/services/key_resolver.py
+++ b/app/services/key_resolver.py
@@ -9,6 +9,7 @@ from app.db.db import Database
 from app.db.entities.organization_key import OrganizationKey
 from app.db.repositories.org_key_repository import OrganizationKeyRepository
 from app.db.repositories.org_repository import OrgRepository
+from app.models.oin import Oin
 from app.rid import RidUsage
 
 logger = logging.getLogger(__name__)
@@ -62,7 +63,7 @@ class KeyResolver:
     def __init__(self, db: Database):
         self.db = db
 
-    def max_rid_usage(self, oin: str) -> Optional[RidUsage]:
+    def max_rid_usage(self, oin: Oin) -> Optional[RidUsage]:
         with self.db.get_db_session() as session:
             org = session.get_repository(OrgRepository).get_by_oin(oin)
             if org is None:

--- a/app/services/mtls_service.py
+++ b/app/services/mtls_service.py
@@ -96,12 +96,11 @@ class MtlsService:
             logger.warning(f"Unable to read certificate from header {e}")
             raise InvalidOinCertificate()
 
-    def get_oin_from_cert(self, cert: x509.Certificate) -> str:
+    def get_oin_from_cert(self, cert: x509.Certificate) -> Oin:
         attr = cert.subject.get_attributes_for_oid(x509.oid.NameOID.SERIAL_NUMBER)
         value = attr[0].value
         try:
-            oin = Oin(value if isinstance(value, str) else value.decode())
-            return oin.value
+            return Oin(value if isinstance(value, str) else value.decode())
 
         except ValueError as e:
             logger.warning(f"Invalid OIN in certificate {e}")
@@ -113,7 +112,8 @@ class MtlsService:
         org = self.org_service.get_by_oin(oin)
         if org is None:
             raise HTTPException(
-                status_code=400, detail=f"organization for OIN {oin} is not registered"
+                status_code=400,
+                detail=f"organization for OIN {oin.value} is not registered",
             )
 
         return org

--- a/app/services/oprf/oprf_service.py
+++ b/app/services/oprf/oprf_service.py
@@ -13,6 +13,7 @@ from app.models.requests import BlindRequest
 
 logger = logging.getLogger(__name__)
 
+
 class HsmKeyLabel:
     def __init__(self, oin: Oin, version: int):
         self.oin = oin
@@ -100,7 +101,9 @@ class OprfService:
             raise ValueError("HSM key version service not configured")
         # The active key versions are stored in the database, keyed by OIN number.
         try:
-            oin = Oin(recipient_org[4:] if recipient_org.startswith("oin:") else recipient_org)
+            oin = Oin(
+                recipient_org[4:] if recipient_org.startswith("oin:") else recipient_org
+            )
         except ValueError as e:
             raise ValueError("Incorrect OIN: %r", e)
 
@@ -142,7 +145,7 @@ class OprfService:
         )
         response.raise_for_status()
 
-        if not 'result' in response.json():
+        if "result" not in response.json():
             raise ValueError("HSM configuration not found")
 
     def _label_exists(self, label: HsmKeyLabel) -> bool:
@@ -167,9 +170,8 @@ class OprfService:
         )
         response.raise_for_status()
 
-        result = response.json()['objects'] or []
+        result = response.json()["objects"] or []
         return len(result) > 0
-
 
     def _evaluate_label(self, label: HsmKeyLabel, blinded_bytes: bytes) -> bytes:
         cfg = self.__hsm_config

--- a/app/services/oprf/oprf_service.py
+++ b/app/services/oprf/oprf_service.py
@@ -76,7 +76,7 @@ class OprfService:
         }
 
         jwe = BlindJwe.build(
-            audience=req.recipientOrganization,
+            audience=str(req.recipientOrganization),
             scope=req.recipientScope,
             subject=subject,
             pub_key=pub_key,
@@ -91,7 +91,7 @@ class OprfService:
         return jwe
 
     def _eval_via_hsm(
-        self, recipient_org: str, blinded_bytes: bytes
+        self, recipient_org_oin: Oin, blinded_bytes: bytes
     ) -> dict[int, bytes]:
         cfg = self.__hsm_config
         if cfg is None:
@@ -100,23 +100,18 @@ class OprfService:
         if self.__hsm_key_version_service is None:
             raise ValueError("HSM key version service not configured")
         # The active key versions are stored in the database, keyed by OIN number.
-        try:
-            oin = Oin(
-                recipient_org[4:] if recipient_org.startswith("oin:") else recipient_org
-            )
-        except ValueError as e:
-            raise ValueError("Incorrect OIN: %r", e)
-
-        active = self.__hsm_key_version_service.get_active_versions(oin=oin)
+        active = self.__hsm_key_version_service.get_active_versions(
+            oin=recipient_org_oin
+        )
         versions = sorted({v.version for v in active})
         if not versions:
-            raise ValueError(f"no active key version for oin {oin}")
+            raise ValueError(f"no active key version for oin {recipient_org_oin}")
 
         # Evaluate the blind against every active key version, so the result holds
         # one entry per version (e.g. during key rotation).
         ret: dict[int, bytes] = {}
         for version in versions:
-            label = HsmKeyLabel(oin, version)
+            label = HsmKeyLabel(recipient_org_oin, version)
             if not self._label_exists(label):
                 self._generate_key(label)
 

--- a/app/services/org_service.py
+++ b/app/services/org_service.py
@@ -3,6 +3,7 @@ import uuid
 from app.db.db import Database
 from app.db.entities.organization import Organization
 from app.db.repositories.org_repository import OrgRepository
+from app.models.oin import Oin
 from app.rid import RidUsage
 import logging
 
@@ -13,12 +14,12 @@ class OrgService:
     def __init__(self, db: Database) -> None:
         self.__db = db
 
-    def get_by_oin(self, oin: str) -> Organization | None:
+    def get_by_oin(self, oin: Oin) -> Organization | None:
         with self.__db.get_db_session() as session:
             repo = session.get_repository(OrgRepository)
             return repo.get_by_oin(oin)
 
-    def create(self, oin: str, name: str, max_key_usage: RidUsage) -> Organization:
+    def create(self, oin: Oin, name: str, max_key_usage: RidUsage) -> Organization:
         with self.__db.get_db_session() as session:
             try:
                 repo = session.get_repository(OrgRepository)

--- a/tests/test_hsm_key_cleanup_service.py
+++ b/tests/test_hsm_key_cleanup_service.py
@@ -21,12 +21,9 @@ TEST_OIN_111 = Oin("00000099000000011000")
 
 def _add(db: Database, oin: Oin, **kwargs: object) -> None:
     with db.get_db_session() as session:
-        oin_value = str(oin)
-        org = session.query(Organization).filter(Organization.oin == oin_value).first()
+        org = session.query(Organization).filter(Organization.oin == oin.value).first()
         if org is None:
-            org = Organization(
-                oin=oin_value, name=f"org-{oin_value}", max_rid_usage="irp"
-            )
+            org = Organization(oin=oin, name=f"org-{oin.value}", max_rid_usage="irp")
             session.add(org)
             session.flush()
         session.add(HsmKeyVersion(organization_id=org.id, **kwargs))
@@ -97,7 +94,7 @@ def test_cleanup_removes_expired_keys_from_hsm_and_db(database: Database) -> Non
     version_service = HsmKeyVersionService(database)
     assert version_service.get_expired_versions() == []
     active = {(v.oin, v.version) for v in version_service.get_active_versions()}
-    assert active == {(str(TEST_OIN_ACTIVE), 2)}
+    assert active == {(TEST_OIN_ACTIVE, 2)}
 
 
 def test_cleanup_skips_when_hsm_not_configured(database: Database) -> None:
@@ -181,7 +178,7 @@ def test_get_expired_versions_filters(database: Database) -> None:
     )  # expired but already removed
 
     expired = HsmKeyVersionService(database).get_expired_versions()
-    assert {v.oin for v in expired} == {str(TEST_OIN_111)}
+    assert {v.oin for v in expired} == {TEST_OIN_111}
 
 
 @pytest.mark.parametrize("hsm_url", ["", None])

--- a/tests/test_hsm_key_cleanup_service.py
+++ b/tests/test_hsm_key_cleanup_service.py
@@ -8,15 +8,25 @@ from app.config import ConfigOprf
 from app.db.db import Database
 from app.db.entities.hsm_key_versions import HsmKeyVersion
 from app.db.entities.organization import Organization
+from app.models.oin import Oin
 from app.services.hsm_key_cleanup_service import HsmKeyCleanupService
 from app.services.hsm_key_version_service import HsmKeyVersionService
 
+TEST_OIN = Oin("00000099000000001000")
+TEST_OIN_EXPIRED_OTHER = Oin("00000099000001001000")
+TEST_OIN_ACTIVE = Oin("00000099000001000000")
+TEST_OIN_REMOVED = Oin("00000099000001003000")
+TEST_OIN_111 = Oin("00000099000000011000")
 
-def _add(db: Database, oin: str, **kwargs: object) -> None:
+
+def _add(db: Database, oin: Oin, **kwargs: object) -> None:
     with db.get_db_session() as session:
-        org = session.query(Organization).filter(Organization.oin == oin).first()
+        oin_value = str(oin)
+        org = session.query(Organization).filter(Organization.oin == oin_value).first()
         if org is None:
-            org = Organization(oin=oin, name=f"org-{oin}", max_rid_usage="irp")
+            org = Organization(
+                oin=oin_value, name=f"org-{oin_value}", max_rid_usage="irp"
+            )
             session.add(org)
             session.flush()
         session.add(HsmKeyVersion(organization_id=org.id, **kwargs))
@@ -34,7 +44,7 @@ def test_cleanup_removes_expired_keys_from_hsm_and_db(database: Database) -> Non
     # expired, not removed -> should be cleaned up
     _add(
         database,
-        oin="00000099000000001000",
+        oin=TEST_OIN,
         version=1,
         from_dt=now - timedelta(days=10),
         until_dt=now - timedelta(days=1),
@@ -42,7 +52,7 @@ def test_cleanup_removes_expired_keys_from_hsm_and_db(database: Database) -> Non
     # expired for a different org -> should be cleaned up too
     _add(
         database,
-        oin="00000099000001001000",
+        oin=TEST_OIN_EXPIRED_OTHER,
         version=1,
         from_dt=now - timedelta(days=10),
         until_dt=now - timedelta(days=2),
@@ -50,7 +60,7 @@ def test_cleanup_removes_expired_keys_from_hsm_and_db(database: Database) -> Non
     # active (no end date) -> must be left alone
     _add(
         database,
-        oin="00000099000001000000",
+        oin=TEST_OIN_ACTIVE,
         version=2,
         from_dt=now - timedelta(days=1),
         until_dt=None,
@@ -58,7 +68,7 @@ def test_cleanup_removes_expired_keys_from_hsm_and_db(database: Database) -> Non
     # already removed -> must be ignored
     _add(
         database,
-        oin="00000099000001000000",
+        oin=TEST_OIN_ACTIVE,
         version=3,
         from_dt=now - timedelta(days=5),
         until_dt=now - timedelta(days=1),
@@ -77,8 +87,8 @@ def test_cleanup_removes_expired_keys_from_hsm_and_db(database: Database) -> Non
     # The right keys are destroyed in the HSM, by their stored label.
     labels = {call.kwargs["json"]["label"] for call in post.call_args_list}
     assert labels == {
-        "oin-00000099000000001000-v1",
-        "oin-00000099000001001000-v1",
+        f"oin-{TEST_OIN}-v1",
+        f"oin-{TEST_OIN_EXPIRED_OTHER}-v1",
     }
     urls = {call.args[0] for call in post.call_args_list}
     assert urls == {"https://hsm.local/hsm/softhsm/SoftHSMLabel/destroy"}
@@ -87,14 +97,14 @@ def test_cleanup_removes_expired_keys_from_hsm_and_db(database: Database) -> Non
     version_service = HsmKeyVersionService(database)
     assert version_service.get_expired_versions() == []
     active = {(v.oin, v.version) for v in version_service.get_active_versions()}
-    assert active == {("00000099000001000000", 2)}
+    assert active == {(str(TEST_OIN_ACTIVE), 2)}
 
 
 def test_cleanup_skips_when_hsm_not_configured(database: Database) -> None:
     now = datetime.now(timezone.utc)
     _add(
         database,
-        oin="00000099000001000000",
+        oin=TEST_OIN_ACTIVE,
         version=1,
         from_dt=now - timedelta(days=10),
         until_dt=now - timedelta(days=1),
@@ -117,7 +127,7 @@ def test_cleanup_keeps_version_when_hsm_destroy_fails(database: Database) -> Non
     now = datetime.now(timezone.utc)
     _add(
         database,
-        oin="00000099000000001000",
+        oin=TEST_OIN,
         version=1,
         from_dt=now - timedelta(days=10),
         until_dt=now - timedelta(days=1),
@@ -142,28 +152,28 @@ def test_get_expired_versions_filters(database: Database) -> None:
     now = datetime.now(timezone.utc)
     _add(
         database,
-        oin="111",
+        oin=TEST_OIN_111,
         version=1,
         from_dt=now - timedelta(days=2),
         until_dt=now - timedelta(days=1),
     )  # expired
     _add(
         database,
-        oin="00000099000000001000",
+        oin=TEST_OIN,
         version=1,
         from_dt=now - timedelta(days=2),
         until_dt=None,
     )  # active, no end
     _add(
         database,
-        oin="00000099000001001000",
+        oin=TEST_OIN_EXPIRED_OTHER,
         version=1,
         from_dt=now - timedelta(days=2),
         until_dt=now + timedelta(days=1),
     )  # active, future end
     _add(
         database,
-        oin="00000099000001003000",
+        oin=TEST_OIN_REMOVED,
         version=1,
         from_dt=now - timedelta(days=2),
         until_dt=now - timedelta(days=1),
@@ -171,7 +181,7 @@ def test_get_expired_versions_filters(database: Database) -> None:
     )  # expired but already removed
 
     expired = HsmKeyVersionService(database).get_expired_versions()
-    assert {v.oin for v in expired} == {"111"}
+    assert {v.oin for v in expired} == {str(TEST_OIN_111)}
 
 
 @pytest.mark.parametrize("hsm_url", ["", None])

--- a/tests/test_hsm_key_version_integration.py
+++ b/tests/test_hsm_key_version_integration.py
@@ -25,13 +25,14 @@ from app import container
 from app.config import ConfigOprf
 from app.db.db import Database
 from app.rid import RidUsage
+from app.models.oin import Oin
 from app.services.hsm_key_version_service import HsmKeyVersionService
 from app.services.key_resolver import KeyResolver
 from app.services.oprf.oprf_service import OprfService
 from app.services.org_service import OrgService
 
-OIN = "00000099000000001000"
-RECIPIENT_ORG = f"oin:{OIN}"
+TEST_OIN = Oin("00000099000000001000")
+RECIPIENT_ORG = f"oin:{TEST_OIN}"
 SCOPE = "nvi"
 
 
@@ -93,7 +94,7 @@ def _eval(client: TestClient) -> Any:
             "recipientOrganization": RECIPIENT_ORG,
             "recipientScope": SCOPE,
         },
-        headers={"x-gf-oin": OIN, "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
     )
 
 
@@ -106,7 +107,7 @@ def test_new_key_version_is_added_to_jwe(
 ) -> None:
     # 1. Register an organization with a public key.
     org = org_service.create(
-        oin=OIN, name=f"Org {OIN}", max_key_usage=RidUsage.ReversiblePseudonym
+        oin=TEST_OIN, name=f"Org {TEST_OIN}", max_key_usage=RidUsage.ReversiblePseudonym
     )
     private_key_pem, public_key_pem = _generate_rsa_keypair()
     key_resolver.create(org.id, [SCOPE], None, public_key_pem)
@@ -127,8 +128,8 @@ def test_new_key_version_is_added_to_jwe(
             # 2. Create version 1 of the HSM key.
             resp = client.post(
                 "/key-versions",
-                json={"oin": OIN},
-                headers={"x-gf-oin": OIN, "x-gf-audience": "prs.service"},
+                json={"oin": str(TEST_OIN)},
+                headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
             )
             assert resp.status_code == 201
             assert resp.json()["version"] == 1
@@ -145,8 +146,8 @@ def test_new_key_version_is_added_to_jwe(
             # 4. Create version 2 of the HSM key.
             resp = client.post(
                 "/key-versions",
-                json={"oin": OIN},
-                headers={"x-gf-oin": OIN, "x-gf-audience": "prs.service"},
+                json={"oin": str(TEST_OIN)},
+                headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
             )
             assert resp.status_code == 201
             assert resp.json()["version"] == 2

--- a/tests/test_hsm_key_version_integration.py
+++ b/tests/test_hsm_key_version_integration.py
@@ -94,7 +94,7 @@ def _eval(client: TestClient) -> Any:
             "recipientOrganization": RECIPIENT_ORG,
             "recipientScope": SCOPE,
         },
-        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN.value, "x-gf-audience": "prs.service"},
     )
 
 
@@ -128,8 +128,8 @@ def test_new_key_version_is_added_to_jwe(
             # 2. Create version 1 of the HSM key.
             resp = client.post(
                 "/key-versions",
-                json={"oin": str(TEST_OIN)},
-                headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
+                json={"oin": TEST_OIN.value},
+                headers={"x-gf-oin": TEST_OIN.value, "x-gf-audience": "prs.service"},
             )
             assert resp.status_code == 201
             assert resp.json()["version"] == 1
@@ -146,8 +146,8 @@ def test_new_key_version_is_added_to_jwe(
             # 4. Create version 2 of the HSM key.
             resp = client.post(
                 "/key-versions",
-                json={"oin": str(TEST_OIN)},
-                headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
+                json={"oin": TEST_OIN.value},
+                headers={"x-gf-oin": TEST_OIN.value, "x-gf-audience": "prs.service"},
             )
             assert resp.status_code == 201
             assert resp.json()["version"] == 2

--- a/tests/test_hsm_key_version_router.py
+++ b/tests/test_hsm_key_version_router.py
@@ -10,7 +10,7 @@ from app.services.hsm_key_version_service import HsmKeyVersionService
 from app.services.org_service import OrgService
 
 TEST_OIN = Oin("00000099000000001000")
-TEST_OIN_STR = str(TEST_OIN)
+TEST_OIN_VALUE = TEST_OIN.value
 
 
 def test_create_first_version(
@@ -24,13 +24,13 @@ def test_create_first_version(
 
     response = client.post(
         "/key-versions",
-        json={"oin": TEST_OIN_STR},
-        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
+        json={"oin": TEST_OIN_VALUE},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
 
     assert response.status_code == 201
     body = response.json()
-    assert body["oin"] == TEST_OIN_STR
+    assert body["oin"] == TEST_OIN_VALUE
     assert body["version"] == 1
     assert body["removed"] is False
     assert body["until_dt"] is None
@@ -48,13 +48,13 @@ def test_create_increments_version(
 
     first = client.post(
         "/key-versions",
-        json={"oin": TEST_OIN_STR},
-        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
+        json={"oin": TEST_OIN_VALUE},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
     second = client.post(
         "/key-versions",
-        json={"oin": TEST_OIN_STR},
-        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
+        json={"oin": TEST_OIN_VALUE},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
 
     assert first.json()["version"] == 1
@@ -75,11 +75,11 @@ def test_create_with_explicit_window(
     response = client.post(
         "/key-versions",
         json={
-            "oin": TEST_OIN_STR,
+            "oin": TEST_OIN_VALUE,
             "from_dt": from_dt.isoformat(),
             "until_dt": until_dt.isoformat(),
         },
-        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
 
     assert response.status_code == 201
@@ -91,8 +91,8 @@ def test_create_with_explicit_window(
 def test_create_unknown_org_returns_404(client: TestClient, database: Database) -> None:
     response = client.post(
         "/key-versions",
-        json={"oin": TEST_OIN_STR},
-        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
+        json={"oin": TEST_OIN_VALUE},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
 
     assert response.status_code == 404
@@ -103,7 +103,7 @@ def test_create_invalid_oin_returns_422(client: TestClient, database: Database) 
     response = client.post(
         "/key-versions",
         json={"oin": "not-a-oin"},
-        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
 
     assert response.status_code == 422
@@ -120,8 +120,8 @@ def test_create_persists_version(
 
     client.post(
         "/key-versions",
-        json={"oin": TEST_OIN_STR},
-        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
+        json={"oin": TEST_OIN_VALUE},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
 
     service = HsmKeyVersionService(database)
@@ -139,15 +139,15 @@ def test_update_sets_removed_and_until_dt(
     )
     created = client.post(
         "/key-versions",
-        json={"oin": TEST_OIN_STR},
-        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
+        json={"oin": TEST_OIN_VALUE},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     ).json()
 
     until_dt = datetime(2027, 1, 1, tzinfo=timezone.utc)
     response = client.put(
         f"/key-versions/{created['id']}",
         json={"removed": True, "until_dt": until_dt.isoformat()},
-        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
 
     assert response.status_code == 200
@@ -172,14 +172,14 @@ def test_update_clears_until_dt(
     until_dt = datetime(2027, 1, 1, tzinfo=timezone.utc)
     created = client.post(
         "/key-versions",
-        json={"oin": TEST_OIN_STR, "until_dt": until_dt.isoformat()},
-        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
+        json={"oin": TEST_OIN_VALUE, "until_dt": until_dt.isoformat()},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     ).json()
 
     response = client.put(
         f"/key-versions/{created['id']}",
         json={"removed": False},
-        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
 
     assert response.status_code == 200
@@ -194,7 +194,7 @@ def test_update_unknown_version_returns_404(
     response = client.put(
         f"/key-versions/{uuid.uuid4()}",
         json={"removed": True},
-        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
 
     assert response.status_code == 404
@@ -206,7 +206,7 @@ def test_update_invalid_id_returns_422(client: TestClient, database: Database) -
     response = client.put(
         "/key-versions/not-a-uuid",
         json={"removed": True},
-        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
 
     assert response.status_code == 422
@@ -222,24 +222,24 @@ def test_list_versions_returns_all_for_org(
     )
     client.post(
         "/key-versions",
-        json={"oin": TEST_OIN_STR},
-        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
+        json={"oin": TEST_OIN_VALUE},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
     client.post(
         "/key-versions",
-        json={"oin": TEST_OIN_STR},
-        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
+        json={"oin": TEST_OIN_VALUE},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
 
     response = client.get(
-        f"/key-versions/{TEST_OIN_STR}",
-        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
+        f"/key-versions/{TEST_OIN_VALUE}",
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
 
     assert response.status_code == 200
     body = response.json()
     assert [v["version"] for v in body] == [1, 2]
-    assert {v["oin"] for v in body} == {TEST_OIN_STR}
+    assert {v["oin"] for v in body} == {TEST_OIN_VALUE}
 
 
 def test_list_versions_includes_removed(
@@ -252,18 +252,18 @@ def test_list_versions_includes_removed(
     )
     created = client.post(
         "/key-versions",
-        json={"oin": TEST_OIN_STR},
-        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
+        json={"oin": TEST_OIN_VALUE},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     ).json()
     client.put(
         f"/key-versions/{created['id']}",
         json={"removed": True},
-        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
 
     response = client.get(
-        f"/key-versions/{TEST_OIN_STR}",
-        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
+        f"/key-versions/{TEST_OIN_VALUE}",
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
 
     assert response.status_code == 200
@@ -282,8 +282,8 @@ def test_list_versions_empty_for_org_without_versions(
     )
 
     response = client.get(
-        f"/key-versions/{TEST_OIN_STR}",
-        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
+        f"/key-versions/{TEST_OIN_VALUE}",
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
 
     assert response.status_code == 200
@@ -294,8 +294,8 @@ def test_list_versions_unknown_org_returns_404(
     client: TestClient, database: Database
 ) -> None:
     response = client.get(
-        f"/key-versions/{TEST_OIN_STR}",
-        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
+        f"/key-versions/{TEST_OIN_VALUE}",
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
 
     assert response.status_code == 404

--- a/tests/test_hsm_key_version_router.py
+++ b/tests/test_hsm_key_version_router.py
@@ -9,25 +9,28 @@ from app.rid import RidUsage
 from app.services.hsm_key_version_service import HsmKeyVersionService
 from app.services.org_service import OrgService
 
+TEST_OIN = Oin("00000099000000001000")
+TEST_OIN_STR = str(TEST_OIN)
+
 
 def test_create_first_version(
     client: TestClient, database: Database, org_service: OrgService
 ) -> None:
     org_service.create(
-        "00000099000000001000",
-        "MyOrg-00000099000000001000",
+        TEST_OIN,
+        f"MyOrg-{TEST_OIN}",
         RidUsage.IrreversiblePseudonym,
     )
 
     response = client.post(
         "/key-versions",
-        json={"oin": "00000099000000001000"},
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        json={"oin": TEST_OIN_STR},
+        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
     )
 
     assert response.status_code == 201
     body = response.json()
-    assert body["oin"] == "00000099000000001000"
+    assert body["oin"] == TEST_OIN_STR
     assert body["version"] == 1
     assert body["removed"] is False
     assert body["until_dt"] is None
@@ -38,18 +41,20 @@ def test_create_increments_version(
     client: TestClient, database: Database, org_service: OrgService
 ) -> None:
     org_service.create(
-        "00000099000000001000", "MyOrg-12345678", RidUsage.IrreversiblePseudonym
+        TEST_OIN,
+        "MyOrg-12345678",
+        RidUsage.IrreversiblePseudonym,
     )
 
     first = client.post(
         "/key-versions",
-        json={"oin": "00000099000000001000"},
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        json={"oin": TEST_OIN_STR},
+        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
     )
     second = client.post(
         "/key-versions",
-        json={"oin": "00000099000000001000"},
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        json={"oin": TEST_OIN_STR},
+        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
     )
 
     assert first.json()["version"] == 1
@@ -60,7 +65,9 @@ def test_create_with_explicit_window(
     client: TestClient, database: Database, org_service: OrgService
 ) -> None:
     org_service.create(
-        "00000099000000001000", "MyOrg-12345678", RidUsage.IrreversiblePseudonym
+        TEST_OIN,
+        "MyOrg-12345678",
+        RidUsage.IrreversiblePseudonym,
     )
 
     from_dt = datetime(2026, 1, 1, tzinfo=timezone.utc)
@@ -68,11 +75,11 @@ def test_create_with_explicit_window(
     response = client.post(
         "/key-versions",
         json={
-            "oin": "00000099000000001000",
+            "oin": TEST_OIN_STR,
             "from_dt": from_dt.isoformat(),
             "until_dt": until_dt.isoformat(),
         },
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
     )
 
     assert response.status_code == 201
@@ -84,21 +91,19 @@ def test_create_with_explicit_window(
 def test_create_unknown_org_returns_404(client: TestClient, database: Database) -> None:
     response = client.post(
         "/key-versions",
-        json={"oin": "00000099000000001000"},
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        json={"oin": TEST_OIN_STR},
+        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
     )
 
     assert response.status_code == 404
-    assert response.json() == {
-        "detail": "organization with oin 00000099000000001000 not found"
-    }
+    assert response.json() == {"detail": f"organization with oin {TEST_OIN} not found"}
 
 
 def test_create_invalid_oin_returns_422(client: TestClient, database: Database) -> None:
     response = client.post(
         "/key-versions",
         json={"oin": "not-a-oin"},
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
     )
 
     assert response.status_code == 422
@@ -108,19 +113,19 @@ def test_create_persists_version(
     client: TestClient, database: Database, org_service: OrgService
 ) -> None:
     org_service.create(
-        "00000099000000001000",
-        "MyOrg-00000099000000001000",
+        TEST_OIN,
+        f"MyOrg-{TEST_OIN}",
         RidUsage.IrreversiblePseudonym,
     )
 
     client.post(
         "/key-versions",
-        json={"oin": "00000099000000001000"},
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        json={"oin": TEST_OIN_STR},
+        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
     )
 
     service = HsmKeyVersionService(database)
-    active = service.get_active_versions(oin=Oin("00000099000000001000"))
+    active = service.get_active_versions(oin=TEST_OIN)
     assert [v.version for v in active] == [1]
 
 
@@ -128,21 +133,21 @@ def test_update_sets_removed_and_until_dt(
     client: TestClient, database: Database, org_service: OrgService
 ) -> None:
     org_service.create(
-        "00000099000000001000",
-        "MyOrg-00000099000000001000",
+        TEST_OIN,
+        f"MyOrg-{TEST_OIN}",
         RidUsage.IrreversiblePseudonym,
     )
     created = client.post(
         "/key-versions",
-        json={"oin": "00000099000000001000"},
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        json={"oin": TEST_OIN_STR},
+        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
     ).json()
 
     until_dt = datetime(2027, 1, 1, tzinfo=timezone.utc)
     response = client.put(
         f"/key-versions/{created['id']}",
         json={"removed": True, "until_dt": until_dt.isoformat()},
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
     )
 
     assert response.status_code == 200
@@ -153,28 +158,28 @@ def test_update_sets_removed_and_until_dt(
 
     # The removed version is no longer returned as active.
     service = HsmKeyVersionService(database)
-    assert service.get_active_versions(oin=Oin("00000099000000001000")) == []
+    assert service.get_active_versions(oin=TEST_OIN) == []
 
 
 def test_update_clears_until_dt(
     client: TestClient, database: Database, org_service: OrgService
 ) -> None:
     org_service.create(
-        "00000099000000001000",
-        "MyOrg-00000099000000001000",
+        TEST_OIN,
+        f"MyOrg-{TEST_OIN}",
         RidUsage.IrreversiblePseudonym,
     )
     until_dt = datetime(2027, 1, 1, tzinfo=timezone.utc)
     created = client.post(
         "/key-versions",
-        json={"oin": "00000099000000001000", "until_dt": until_dt.isoformat()},
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        json={"oin": TEST_OIN_STR, "until_dt": until_dt.isoformat()},
+        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
     ).json()
 
     response = client.put(
         f"/key-versions/{created['id']}",
         json={"removed": False},
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
     )
 
     assert response.status_code == 200
@@ -189,7 +194,7 @@ def test_update_unknown_version_returns_404(
     response = client.put(
         f"/key-versions/{uuid.uuid4()}",
         json={"removed": True},
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
     )
 
     assert response.status_code == 404
@@ -201,7 +206,7 @@ def test_update_invalid_id_returns_422(client: TestClient, database: Database) -
     response = client.put(
         "/key-versions/not-a-uuid",
         json={"removed": True},
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
     )
 
     assert response.status_code == 422
@@ -211,54 +216,54 @@ def test_list_versions_returns_all_for_org(
     client: TestClient, database: Database, org_service: OrgService
 ) -> None:
     org_service.create(
-        "00000099000000001000",
-        "MyOrg-00000099000000001000",
+        TEST_OIN,
+        f"MyOrg-{TEST_OIN}",
         RidUsage.IrreversiblePseudonym,
     )
     client.post(
         "/key-versions",
-        json={"oin": "00000099000000001000"},
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        json={"oin": TEST_OIN_STR},
+        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
     )
     client.post(
         "/key-versions",
-        json={"oin": "00000099000000001000"},
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        json={"oin": TEST_OIN_STR},
+        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
     )
 
     response = client.get(
-        "/key-versions/00000099000000001000",
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        f"/key-versions/{TEST_OIN_STR}",
+        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
     )
 
     assert response.status_code == 200
     body = response.json()
     assert [v["version"] for v in body] == [1, 2]
-    assert {v["oin"] for v in body} == {"00000099000000001000"}
+    assert {v["oin"] for v in body} == {TEST_OIN_STR}
 
 
 def test_list_versions_includes_removed(
     client: TestClient, database: Database, org_service: OrgService
 ) -> None:
     org_service.create(
-        "00000099000000001000",
-        "MyOrg-00000099000000001000",
+        TEST_OIN,
+        f"MyOrg-{TEST_OIN}",
         RidUsage.IrreversiblePseudonym,
     )
     created = client.post(
         "/key-versions",
-        json={"oin": "00000099000000001000"},
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        json={"oin": TEST_OIN_STR},
+        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
     ).json()
     client.put(
         f"/key-versions/{created['id']}",
         json={"removed": True},
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
     )
 
     response = client.get(
-        "/key-versions/00000099000000001000",
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        f"/key-versions/{TEST_OIN_STR}",
+        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
     )
 
     assert response.status_code == 200
@@ -271,14 +276,14 @@ def test_list_versions_empty_for_org_without_versions(
     client: TestClient, database: Database, org_service: OrgService
 ) -> None:
     org_service.create(
-        "00000099000000001000",
-        "MyOrg-00000099000000001000",
+        TEST_OIN,
+        f"MyOrg-{TEST_OIN}",
         RidUsage.IrreversiblePseudonym,
     )
 
     response = client.get(
-        "/key-versions/00000099000000001000",
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        f"/key-versions/{TEST_OIN_STR}",
+        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
     )
 
     assert response.status_code == 200
@@ -289,8 +294,8 @@ def test_list_versions_unknown_org_returns_404(
     client: TestClient, database: Database
 ) -> None:
     response = client.get(
-        "/key-versions/00000099000000001000",
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        f"/key-versions/{TEST_OIN_STR}",
+        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
     )
 
     assert response.status_code == 404

--- a/tests/test_hsm_key_version_service.py
+++ b/tests/test_hsm_key_version_service.py
@@ -1,7 +1,7 @@
 import base64
 import json
 from datetime import datetime, timedelta, timezone
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -11,14 +11,28 @@ from app.db.entities.hsm_key_versions import HsmKeyVersion
 from app.db.entities.organization import Organization
 from app.models.oin import Oin
 from app.services.hsm_key_version_service import HsmKeyVersionService
-from app.services.oprf.oprf_service import OprfService, HsmKeyLabel
+from app.services.oprf.oprf_service import OprfService
 
 
-def _add(db: Database, oin: str, **kwargs: object) -> None:
+TEST_OIN = Oin("00000099000000001000")
+TEST_OIN_WITH_PREFIX = f"oin:{TEST_OIN}"
+TEST_OIN_111 = Oin("00000099000000011000")
+TEST_OIN_222 = Oin("00000099000000022000")
+TEST_OIN_333 = Oin("00000099000000033000")
+TEST_OIN_444 = Oin("00000099000000044000")
+TEST_OIN_555 = Oin("00000099000000055000")
+TEST_OIN_78000 = Oin("00000000012345678000")
+TEST_OIN_79000 = Oin("00000000012345679000")
+
+
+def _add(db: Database, oin: Oin, **kwargs: object) -> None:
     with db.get_db_session() as session:
-        org = session.query(Organization).filter(Organization.oin == oin).first()
+        oin_value = str(oin)
+        org = session.query(Organization).filter(Organization.oin == oin_value).first()
         if org is None:
-            org = Organization(oin=oin, name=f"org-{oin}", max_rid_usage="irp")
+            org = Organization(
+                oin=oin_value, name=f"org-{oin_value}", max_rid_usage="irp"
+            )
             session.add(org)
             session.flush()
         session.add(HsmKeyVersion(organization_id=org.id, **kwargs))
@@ -28,21 +42,33 @@ def _add(db: Database, oin: str, **kwargs: object) -> None:
 def test_get_active_versions_filters_by_date_and_removed(database: Database) -> None:
     now = datetime.now(timezone.utc)
     # active: started, no end date
-    _add(database, oin="111", version=1, from_dt=now - timedelta(days=1), until_dt=None)
+    _add(
+        database,
+        oin=TEST_OIN_111,
+        version=1,
+        from_dt=now - timedelta(days=1),
+        until_dt=None,
+    )
     # active: within window
     _add(
         database,
-        oin="222",
+        oin=TEST_OIN_222,
         version=2,
         from_dt=now - timedelta(days=1),
         until_dt=now + timedelta(days=1),
     )
     # inactive: not started yet
-    _add(database, oin="333", version=3, from_dt=now + timedelta(days=1), until_dt=None)
+    _add(
+        database,
+        oin=TEST_OIN_333,
+        version=3,
+        from_dt=now + timedelta(days=1),
+        until_dt=None,
+    )
     # inactive: already ended
     _add(
         database,
-        oin="444",
+        oin=TEST_OIN_444,
         version=4,
         from_dt=now - timedelta(days=2),
         until_dt=now - timedelta(days=1),
@@ -50,7 +76,7 @@ def test_get_active_versions_filters_by_date_and_removed(database: Database) -> 
     # inactive: removed
     _add(
         database,
-        oin="555",
+        oin=TEST_OIN_555,
         version=5,
         from_dt=now - timedelta(days=1),
         until_dt=None,
@@ -60,17 +86,27 @@ def test_get_active_versions_filters_by_date_and_removed(database: Database) -> 
     service = HsmKeyVersionService(database)
     active = {v.oin for v in service.get_active_versions()}
 
-    assert active == {"111", "222"}
+    assert active == {str(TEST_OIN_111), str(TEST_OIN_222)}
 
 
 def test_eval_via_hsm_returns_entry_per_active_version(database: Database) -> None:
     now = datetime.now(timezone.utc)
-    _add(database, oin="00000000012345678000", version=2, from_dt=now - timedelta(days=2))
-    _add(database, oin="00000000012345678000", version=7, from_dt=now - timedelta(days=1))
+    _add(
+        database,
+        oin=TEST_OIN_78000,
+        version=2,
+        from_dt=now - timedelta(days=2),
+    )
+    _add(
+        database,
+        oin=TEST_OIN_78000,
+        version=7,
+        from_dt=now - timedelta(days=1),
+    )
     # a removed version must be ignored
     _add(
         database,
-        oin="00000000012345678000",
+        oin=TEST_OIN_78000,
         version=9,
         from_dt=now - timedelta(days=1),
         removed=True,
@@ -84,9 +120,11 @@ def test_eval_via_hsm_returns_entry_per_active_version(database: Database) -> No
 
     with (
         patch.object(service, "_label_exists", return_value=True) as label_exists,
-        patch.object(service, "_evaluate_label", return_value=b"evaluated") as evaluate_label,
+        patch.object(
+            service, "_evaluate_label", return_value=b"evaluated"
+        ) as evaluate_label,
     ):
-        result = service._eval_via_hsm("oin:00000000012345678000", b"blinded")
+        result = service._eval_via_hsm(f"oin:{TEST_OIN_78000}", b"blinded")
 
     assert result == {2: b"evaluated", 7: b"evaluated"}
 
@@ -106,7 +144,12 @@ def test_eval_via_hsm_returns_entry_per_active_version(database: Database) -> No
 
 def test_eval_generates_keys_if_needed(database: Database) -> None:
     now = datetime.now(timezone.utc)
-    _add(database, oin="00000000012345679000", version=1, from_dt=now - timedelta(days=2))
+    _add(
+        database,
+        oin=TEST_OIN_79000,
+        version=1,
+        from_dt=now - timedelta(days=2),
+    )
 
     service = OprfService(
         server_key=None,
@@ -117,9 +160,11 @@ def test_eval_generates_keys_if_needed(database: Database) -> None:
     with (
         patch.object(service, "_label_exists", return_value=False) as label_exists,
         patch.object(service, "_generate_key") as generate_key,
-        patch.object(service, "_evaluate_label", return_value=b"evaluated") as evaluate_label,
+        patch.object(
+            service, "_evaluate_label", return_value=b"evaluated"
+        ) as evaluate_label,
     ):
-        result = service._eval_via_hsm("oin:00000000012345679000", b"blinded")
+        result = service._eval_via_hsm(f"oin:{TEST_OIN_79000}", b"blinded")
 
     assert result == {1: b"evaluated"}
 
@@ -147,8 +192,18 @@ def test_eval_blind_subject_is_latest_with_extra_versions(database: Database) ->
     from app.models.requests import BlindRequest
 
     now = datetime.now(timezone.utc)
-    _add(database, oin="00000000012345678000", version=2, from_dt=now - timedelta(days=2))
-    _add(database, oin="00000000012345678000", version=7, from_dt=now - timedelta(days=1))
+    _add(
+        database,
+        oin=TEST_OIN_78000,
+        version=2,
+        from_dt=now - timedelta(days=2),
+    )
+    _add(
+        database,
+        oin=TEST_OIN_78000,
+        version=7,
+        from_dt=now - timedelta(days=1),
+    )
 
     service = OprfService(
         server_key=None,
@@ -212,7 +267,7 @@ def test_eval_blind_jwe_contains_only_versions_active_at_date(
     # expired: ended yesterday -> excluded
     _add(
         database,
-        oin="00000099000000001000",
+        oin=TEST_OIN,
         version=1,
         from_dt=now - timedelta(days=10),
         until_dt=now - timedelta(days=1),
@@ -220,7 +275,7 @@ def test_eval_blind_jwe_contains_only_versions_active_at_date(
     # active: started, no end date
     _add(
         database,
-        oin="00000099000000001000",
+        oin=TEST_OIN,
         version=3,
         from_dt=now - timedelta(days=5),
         until_dt=None,
@@ -228,7 +283,7 @@ def test_eval_blind_jwe_contains_only_versions_active_at_date(
     # active: within window
     _add(
         database,
-        oin="00000099000000001000",
+        oin=TEST_OIN,
         version=5,
         from_dt=now - timedelta(days=2),
         until_dt=now + timedelta(days=2),
@@ -236,7 +291,7 @@ def test_eval_blind_jwe_contains_only_versions_active_at_date(
     # future: not started yet -> excluded
     _add(
         database,
-        oin="00000099000000001000",
+        oin=TEST_OIN,
         version=8,
         from_dt=now + timedelta(days=1),
         until_dt=None,
@@ -269,7 +324,7 @@ def test_eval_blind_jwe_contains_only_versions_active_at_date(
 
     req = BlindRequest(
         encryptedPersonalId=base64.urlsafe_b64encode(b"blinded").decode(),
-        recipientOrganization="oin:00000099000000001000",
+        recipientOrganization=TEST_OIN_WITH_PREFIX,
         recipientScope="scope",
     )
 
@@ -299,9 +354,8 @@ def test_eval_via_hsm_without_active_version_raises(database: Database) -> None:
         hsm_config=ConfigOprf(hsm_url="https://hsm.local"),
         hsm_key_version_service=HsmKeyVersionService(database),
     )
-    target = "00000099000000001000"
-    with pytest.raises(ValueError, match=f"no active key version for oin {target}"):
-        service._eval_via_hsm(f"oin:{target}", b"blinded")
+    with pytest.raises(ValueError, match=f"no active key version for oin {TEST_OIN}"):
+        service._eval_via_hsm(TEST_OIN_WITH_PREFIX, b"blinded")
 
 
 def test_eval_via_hsm_without_service_raises() -> None:

--- a/tests/test_hsm_key_version_service.py
+++ b/tests/test_hsm_key_version_service.py
@@ -9,7 +9,7 @@ from app.config import ConfigOprf
 from app.db.db import Database
 from app.db.entities.hsm_key_versions import HsmKeyVersion
 from app.db.entities.organization import Organization
-from app.models.oin import Oin
+from app.models.oin import Oin, RecipientOrganizationOin
 from app.services.hsm_key_version_service import HsmKeyVersionService
 from app.services.oprf.oprf_service import OprfService
 
@@ -27,12 +27,9 @@ TEST_OIN_79000 = Oin("00000000012345679000")
 
 def _add(db: Database, oin: Oin, **kwargs: object) -> None:
     with db.get_db_session() as session:
-        oin_value = str(oin)
-        org = session.query(Organization).filter(Organization.oin == oin_value).first()
+        org = session.query(Organization).filter(Organization.oin == oin.value).first()
         if org is None:
-            org = Organization(
-                oin=oin_value, name=f"org-{oin_value}", max_rid_usage="irp"
-            )
+            org = Organization(oin=oin, name=f"org-{oin.value}", max_rid_usage="irp")
             session.add(org)
             session.flush()
         session.add(HsmKeyVersion(organization_id=org.id, **kwargs))
@@ -86,7 +83,7 @@ def test_get_active_versions_filters_by_date_and_removed(database: Database) -> 
     service = HsmKeyVersionService(database)
     active = {v.oin for v in service.get_active_versions()}
 
-    assert active == {str(TEST_OIN_111), str(TEST_OIN_222)}
+    assert active == {TEST_OIN_111, TEST_OIN_222}
 
 
 def test_eval_via_hsm_returns_entry_per_active_version(database: Database) -> None:
@@ -124,7 +121,7 @@ def test_eval_via_hsm_returns_entry_per_active_version(database: Database) -> No
             service, "_evaluate_label", return_value=b"evaluated"
         ) as evaluate_label,
     ):
-        result = service._eval_via_hsm(f"oin:{TEST_OIN_78000}", b"blinded")
+        result = service._eval_via_hsm(TEST_OIN_78000, b"blinded")
 
     assert result == {2: b"evaluated", 7: b"evaluated"}
 
@@ -164,7 +161,7 @@ def test_eval_generates_keys_if_needed(database: Database) -> None:
             service, "_evaluate_label", return_value=b"evaluated"
         ) as evaluate_label,
     ):
-        result = service._eval_via_hsm(f"oin:{TEST_OIN_79000}", b"blinded")
+        result = service._eval_via_hsm(TEST_OIN_79000, b"blinded")
 
     assert result == {1: b"evaluated"}
 
@@ -232,7 +229,7 @@ def test_eval_blind_subject_is_latest_with_extra_versions(database: Database) ->
 
     req = BlindRequest(
         encryptedPersonalId=base64.urlsafe_b64encode(b"blinded").decode(),
-        recipientOrganization="oin:00000000012345678000",
+        recipientOrganization=RecipientOrganizationOin("oin:00000000012345678000"),
         recipientScope="scope",
     )
 
@@ -324,7 +321,7 @@ def test_eval_blind_jwe_contains_only_versions_active_at_date(
 
     req = BlindRequest(
         encryptedPersonalId=base64.urlsafe_b64encode(b"blinded").decode(),
-        recipientOrganization=TEST_OIN_WITH_PREFIX,
+        recipientOrganization=RecipientOrganizationOin(TEST_OIN_WITH_PREFIX),
         recipientScope="scope",
     )
 
@@ -355,7 +352,7 @@ def test_eval_via_hsm_without_active_version_raises(database: Database) -> None:
         hsm_key_version_service=HsmKeyVersionService(database),
     )
     with pytest.raises(ValueError, match=f"no active key version for oin {TEST_OIN}"):
-        service._eval_via_hsm(TEST_OIN_WITH_PREFIX, b"blinded")
+        service._eval_via_hsm(TEST_OIN, b"blinded")
 
 
 def test_eval_via_hsm_without_service_raises() -> None:
@@ -364,4 +361,4 @@ def test_eval_via_hsm_without_service_raises() -> None:
     )
 
     with pytest.raises(ValueError, match="HSM key version service not configured"):
-        service._eval_via_hsm("oin:00000000012345678000", b"blinded")
+        service._eval_via_hsm(TEST_OIN_78000, b"blinded")

--- a/tests/test_key_resolver.py
+++ b/tests/test_key_resolver.py
@@ -1,5 +1,6 @@
 from jwcrypto import jwk
 
+from app.models.oin import Oin
 from app.rid import RidUsage
 from app.services.key_resolver import KeyResolver, KeyRequest
 from app.services.org_service import OrgService
@@ -11,19 +12,22 @@ hvOXiM1EeTB7me9x2P6t6SznJA7+SQMLHpvD8oKUzbflMjlyW8fs21og2eQ1YNPi
 fRs2Wy5kQi1QlyTzAgMBAAE=
 -----END PUBLIC KEY-----"""
 
+TEST_OIN = Oin("00000099000000001000")
+TEST_OIN_WITH_PREFIX = f"oin:{TEST_OIN}"
+
 
 def test_resolver_create_and_resolve_roundtrip(
     key_resolver: KeyResolver, org_service: OrgService
 ) -> None:
     org = org_service.create(
-        oin="oin:00000099000000001000",
+        oin=TEST_OIN,
         name="test org",
         max_key_usage=RidUsage.ReversiblePseudonym,
     )
 
     # create
     req = KeyRequest(
-        organization="oin:00000099000000001000",
+        organization=TEST_OIN_WITH_PREFIX,
         scope=["NVI", " lmr "],
         pub_key=TEST_PUBKEY,
     )
@@ -41,7 +45,7 @@ def test_resolver_get_and_delete(
     key_resolver: KeyResolver, org_service: OrgService
 ) -> None:
     org = org_service.create(
-        oin="oin:00000099000000001000",
+        oin=TEST_OIN,
         name="test org",
         max_key_usage=RidUsage.ReversiblePseudonym,
     )
@@ -66,7 +70,7 @@ def test_resolver_create_persists_key_id(
     key_resolver: KeyResolver, org_service: OrgService
 ) -> None:
     org = org_service.create(
-        oin="oin:00000099000000001000",
+        oin=TEST_OIN,
         name="test org",
         max_key_usage=RidUsage.ReversiblePseudonym,
     )
@@ -85,7 +89,7 @@ def test_resolver_create_without_key_id(
     key_resolver: KeyResolver, org_service: OrgService
 ) -> None:
     org = org_service.create(
-        oin="oin:00000099000000001000",
+        oin=TEST_OIN,
         name="test org",
         max_key_usage=RidUsage.ReversiblePseudonym,
     )

--- a/tests/test_oprf_integration.py
+++ b/tests/test_oprf_integration.py
@@ -29,7 +29,7 @@ class OprfIntegrationContext:
 
 
 TEST_OIN = Oin("00000099000000001000")
-TEST_OIN_STR = str(TEST_OIN)
+TEST_OIN_VALUE = TEST_OIN.value
 
 
 def generate_rsa_keypair() -> Tuple[str, str]:
@@ -88,7 +88,7 @@ def run_oprf_eval_and_unblind(
             "recipientOrganization": recipient_organization,
             "recipientScope": recipient_scope,
         },
-        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
     assert eval_response.status_code == 200
     token = jwe.JWE()
@@ -191,7 +191,7 @@ def test_oprf_eval_invalid_scope_returns_not_found(
             "recipientOrganization": oprf_context.recipient_organization,
             "recipientScope": "invalid-scope",
         },
-        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
 
     assert eval_response.status_code == 404
@@ -200,7 +200,7 @@ def test_oprf_eval_invalid_scope_returns_not_found(
     }
 
 
-def test_oprf_eval_invalid_recipient_organization_returns_bad_request(
+def test_oprf_eval_invalid_recipient_organization_returns_expected_error(
     client: TestClient,
 ) -> None:
     eval_response = client.post(
@@ -210,13 +210,32 @@ def test_oprf_eval_invalid_recipient_organization_returns_bad_request(
             "recipientOrganization": "12345678",
             "recipientScope": "nvi",
         },
-        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
 
-    assert eval_response.status_code == 400
-    assert eval_response.json() == {
-        "error": "Invalid recipient organization. Format: oin:<oin_number>"
-    }
+    assert eval_response.status_code == 422
+    assert eval_response.json()["detail"][0]["msg"] == (
+        "Invalid recipient organization. Format: oin:<oin_number>"
+    )
+
+
+def test_oprf_eval_invalid_prefixed_recipient_organization_returns_expected_error(
+    client: TestClient,
+) -> None:
+    eval_response = client.post(
+        "/oprf/eval",
+        json={
+            "encryptedPersonalId": "Zm9v",
+            "recipientOrganization": "oin:00000099",
+            "recipientScope": "nvi",
+        },
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
+    )
+
+    assert eval_response.status_code == 422
+    assert eval_response.json()["detail"][0]["msg"] == (
+        "Invalid OIN '00000099'. Expected 20 characters structured as 8 digit prefix + 8/9 alphanumeric mainnumber + 4/3 trailing zeros."
+    )
 
 
 def test_oprf_eval_unknown_oin_returns_not_found(
@@ -254,7 +273,7 @@ def test_oprf_eval_when_service_rejects_blind_returns_bad_request(
                 "recipientOrganization": oprf_context.recipient_organization,
                 "recipientScope": oprf_context.recipient_scope,
             },
-            headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
+            headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
         )
     finally:
         app.dependency_overrides.pop(container.get_oprf_service, None)

--- a/tests/test_oprf_integration.py
+++ b/tests/test_oprf_integration.py
@@ -13,6 +13,7 @@ import pytest
 from fastapi import FastAPI
 from starlette.testclient import TestClient
 
+from app.models.oin import Oin
 from app.rid import RidUsage
 from app import container
 from app.services.key_resolver import KeyResolver
@@ -25,6 +26,10 @@ class OprfIntegrationContext:
     recipient_organization: str
     recipient_scope: str
     private_key_pem: str
+
+
+TEST_OIN = Oin("00000099000000001000")
+TEST_OIN_STR = str(TEST_OIN)
 
 
 def generate_rsa_keypair() -> Tuple[str, str]:
@@ -47,7 +52,7 @@ def generate_rsa_keypair() -> Tuple[str, str]:
 def setup_org_and_key(
     org_service: OrgService,
     key_resolver: KeyResolver,
-    oin: str,
+    oin: Oin,
     scope: str,
 ) -> str:
     org = org_service.create(
@@ -83,7 +88,7 @@ def run_oprf_eval_and_unblind(
             "recipientOrganization": recipient_organization,
             "recipientScope": recipient_scope,
         },
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
     )
     assert eval_response.status_code == 200
     token = jwe.JWE()
@@ -124,7 +129,7 @@ def oprf_context(
     org_service: OrgService,
     key_resolver: KeyResolver,
 ) -> OprfIntegrationContext:
-    recipient_organization = "oin:00000099000000001000"
+    recipient_organization = f"oin:{TEST_OIN}"
     recipient_scope = "nvi"
     personal_identifier = {
         "landCode": "NL",
@@ -134,7 +139,7 @@ def oprf_context(
     private_key_pem = setup_org_and_key(
         org_service=org_service,
         key_resolver=key_resolver,
-        oin="00000099000000001000",
+        oin=TEST_OIN,
         scope=recipient_scope,
     )
     return OprfIntegrationContext(
@@ -186,7 +191,7 @@ def test_oprf_eval_invalid_scope_returns_not_found(
             "recipientOrganization": oprf_context.recipient_organization,
             "recipientScope": "invalid-scope",
         },
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
     )
 
     assert eval_response.status_code == 404
@@ -205,7 +210,7 @@ def test_oprf_eval_invalid_recipient_organization_returns_bad_request(
             "recipientOrganization": "12345678",
             "recipientScope": "nvi",
         },
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
     )
 
     assert eval_response.status_code == 400
@@ -249,10 +254,7 @@ def test_oprf_eval_when_service_rejects_blind_returns_bad_request(
                 "recipientOrganization": oprf_context.recipient_organization,
                 "recipientScope": oprf_context.recipient_scope,
             },
-            headers={
-                "x-gf-oin": "00000099000000001000",
-                "x-gf-audience": "prs.service",
-            },
+            headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
         )
     finally:
         app.dependency_overrides.pop(container.get_oprf_service, None)

--- a/tests/test_oprf_test_router.py
+++ b/tests/test_oprf_test_router.py
@@ -11,6 +11,7 @@ import pyoprf
 import pytest
 from starlette.testclient import TestClient
 
+from app.models.oin import Oin
 from app.rid import RidUsage
 from app.services.key_resolver import KeyResolver
 from app.services.org_service import OrgService
@@ -22,6 +23,10 @@ class OprfTestRouterContext:
     recipient_organization: str
     recipient_scope: str
     private_key_pem: str
+
+
+TEST_OIN = Oin("00000099000000001000")
+TEST_OIN_STR = str(TEST_OIN)
 
 
 def generate_rsa_keypair() -> Tuple[str, str]:
@@ -44,7 +49,7 @@ def generate_rsa_keypair() -> Tuple[str, str]:
 def setup_org_and_key(
     org_service: OrgService,
     key_resolver: KeyResolver,
-    oin: str,
+    oin: Oin,
     scope: str,
 ) -> str:
     org = org_service.create(
@@ -62,7 +67,7 @@ def oprf_test_router_context(
     org_service: OrgService,
     key_resolver: KeyResolver,
 ) -> OprfTestRouterContext:
-    recipient_organization = "oin:00000099000000001000"
+    recipient_organization = f"oin:{TEST_OIN}"
     recipient_scope = "nvi"
     personal_identifier = {
         "landCode": "NL",
@@ -72,7 +77,7 @@ def oprf_test_router_context(
     private_key_pem = setup_org_and_key(
         org_service=org_service,
         key_resolver=key_resolver,
-        oin="00000099000000001000",
+        oin=TEST_OIN,
         scope=recipient_scope,
     )
     return OprfTestRouterContext(
@@ -90,7 +95,7 @@ def test_test_oprf_client_and_receiver_roundtrip(
     client_response = client.post(
         "/test/oprf/client",
         json={"personalId": oprf_test_router_context.personal_identifier},
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
     )
     assert client_response.status_code == 200
 
@@ -104,7 +109,7 @@ def test_test_oprf_client_and_receiver_roundtrip(
             "recipientOrganization": oprf_test_router_context.recipient_organization,
             "recipientScope": oprf_test_router_context.recipient_scope,
         },
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
     )
     assert eval_response.status_code == 200
     jwe_token = eval_response.json()["jwe"]
@@ -116,7 +121,7 @@ def test_test_oprf_client_and_receiver_roundtrip(
             "jwe": jwe_token,
             "priv_key_pem": oprf_test_router_context.private_key_pem,
         },
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
     )
     assert receiver_response.status_code == 200
 
@@ -155,7 +160,7 @@ def test_test_oprf_receiver_invalid_private_key(
             "recipientOrganization": oprf_test_router_context.recipient_organization,
             "recipientScope": oprf_test_router_context.recipient_scope,
         },
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
     )
     assert eval_response.status_code == 200
 
@@ -166,7 +171,7 @@ def test_test_oprf_receiver_invalid_private_key(
             "jwe": eval_response.json()["jwe"],
             "priv_key_pem": "-----BEGIN PRIVATE KEY-----invalid",
         },
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
     )
     assert receiver_response.status_code == 200
     assert receiver_response.json()["jwe"]["decrypted"].startswith(

--- a/tests/test_oprf_test_router.py
+++ b/tests/test_oprf_test_router.py
@@ -26,7 +26,7 @@ class OprfTestRouterContext:
 
 
 TEST_OIN = Oin("00000099000000001000")
-TEST_OIN_STR = str(TEST_OIN)
+TEST_OIN_VALUE = TEST_OIN.value
 
 
 def generate_rsa_keypair() -> Tuple[str, str]:
@@ -95,7 +95,7 @@ def test_test_oprf_client_and_receiver_roundtrip(
     client_response = client.post(
         "/test/oprf/client",
         json={"personalId": oprf_test_router_context.personal_identifier},
-        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
     assert client_response.status_code == 200
 
@@ -109,7 +109,7 @@ def test_test_oprf_client_and_receiver_roundtrip(
             "recipientOrganization": oprf_test_router_context.recipient_organization,
             "recipientScope": oprf_test_router_context.recipient_scope,
         },
-        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
     assert eval_response.status_code == 200
     jwe_token = eval_response.json()["jwe"]
@@ -121,7 +121,7 @@ def test_test_oprf_client_and_receiver_roundtrip(
             "jwe": jwe_token,
             "priv_key_pem": oprf_test_router_context.private_key_pem,
         },
-        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
     assert receiver_response.status_code == 200
 
@@ -160,7 +160,7 @@ def test_test_oprf_receiver_invalid_private_key(
             "recipientOrganization": oprf_test_router_context.recipient_organization,
             "recipientScope": oprf_test_router_context.recipient_scope,
         },
-        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
     assert eval_response.status_code == 200
 
@@ -171,7 +171,7 @@ def test_test_oprf_receiver_invalid_private_key(
             "jwe": eval_response.json()["jwe"],
             "priv_key_pem": "-----BEGIN PRIVATE KEY-----invalid",
         },
-        headers={"x-gf-oin": TEST_OIN_STR, "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
     assert receiver_response.status_code == 200
     assert receiver_response.json()["jwe"]["decrypted"].startswith(

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1,11 +1,20 @@
-from app.models.requests import BlindRequest, RegisterRequest
+from typing import cast
+
+from app.models.oin import Oin, RecipientOrganizationOin
+from app.services.pseudonym_service import PseudonymType
+from app.models.requests import (
+    BlindRequest,
+    ExchangeRequest,
+    RegisterRequest,
+    RidExchangeRequest,
+)
 from pydantic import ValidationError
 
 
 def test_blind_request_encrypted_personal_id_is_normalized() -> None:
     request = BlindRequest(
         encryptedPersonalId="YQ",
-        recipientOrganization="ura:12345678",
+        recipientOrganization=RecipientOrganizationOin("oin:00000099000000001000"),
         recipientScope="nvi",
     )
 
@@ -16,12 +25,90 @@ def test_blind_request_encrypted_personal_id_invalid_base64url() -> None:
     try:
         BlindRequest(
             encryptedPersonalId="a?",
-            recipientOrganization="ura:12345678",
+            recipientOrganization=RecipientOrganizationOin("oin:00000099000000001000"),
             recipientScope="nvi",
         )
         assert False, "Expected ValidationError for invalid base64url"
     except ValidationError as e:
         assert "must be base64url" in str(e)
+
+
+def test_blind_request_invalid_recipient_organization_throws_validation_error() -> None:
+    try:
+        BlindRequest(
+            encryptedPersonalId="YQ",
+            recipientOrganization=cast(RecipientOrganizationOin, "not-a-valid-oin"),
+            recipientScope="nvi",
+        )
+        assert False, "Expected ValidationError for invalid organization OIN"
+    except ValidationError as e:
+        assert "Invalid recipient organization. Format: oin:<oin_number>" in str(e)
+
+
+def test_blind_request_invalid_prefixed_recipient_organization_throws_oin_validation_error() -> (
+    None
+):
+    try:
+        BlindRequest(
+            encryptedPersonalId="YQ",
+            recipientOrganization=cast(RecipientOrganizationOin, "oin:00000099"),
+            recipientScope="nvi",
+        )
+        assert False, "Expected ValidationError for invalid organization OIN"
+    except ValidationError as e:
+        assert "Invalid OIN '00000099'." in str(e)
+
+
+def test_rid_exchange_request_recipient_organization_is_parsed_to_oin() -> None:
+    request = RidExchangeRequest(
+        personalId={"landCode": "NL", "type": "bsn", "value": "9500009012"},
+        recipientOrganization=RecipientOrganizationOin("oin:00000099000000002000"),
+        recipientScope="scope",
+        ridUsage="irp",
+    )
+
+    assert request.recipientOrganization == Oin("00000099000000002000")
+
+
+def test_rid_exchange_request_invalid_recipient_organization_throws_validation_error() -> (
+    None
+):
+    try:
+        RidExchangeRequest(
+            personalId={"landCode": "NL", "type": "bsn", "value": "9500009012"},
+            recipientOrganization=cast(RecipientOrganizationOin, "bad-oin"),
+            recipientScope="scope",
+            ridUsage="irp",
+        )
+        assert False, "Expected ValidationError for invalid organization OIN"
+    except ValidationError as e:
+        assert "Invalid recipient organization. Format: oin:<oin_number>" in str(e)
+
+
+def test_exchange_request_recipient_organization_is_parsed_to_oin() -> None:
+    request = ExchangeRequest(
+        personalId={"landCode": "NL", "type": "bsn", "value": "9500009012"},
+        recipientOrganization=RecipientOrganizationOin("oin:00000099000000003000"),
+        recipientScope="scope",
+        pseudonymType=PseudonymType.Irreversible,
+    )
+
+    assert request.recipientOrganization == Oin("00000099000000003000")
+
+
+def test_exchange_request_invalid_recipient_organization_throws_validation_error() -> (
+    None
+):
+    try:
+        ExchangeRequest(
+            personalId={"landCode": "NL", "type": "bsn", "value": "9500009012"},
+            recipientOrganization=cast(RecipientOrganizationOin, "bad-oin"),
+            recipientScope="scope",
+            pseudonymType=PseudonymType.Irreversible,
+        )
+        assert False, "Expected ValidationError for invalid organization OIN"
+    except ValidationError as e:
+        assert "Invalid recipient organization. Format: oin:<oin_number>" in str(e)
 
 
 def test_register_request_with_key_id() -> None:

--- a/tests/test_rid_router.py
+++ b/tests/test_rid_router.py
@@ -11,6 +11,7 @@ from app.services.org_service import OrgService
 
 TEST_OIN = Oin("00000099000000001000")
 TEST_OIN_WITH_PREFIX = f"oin:{TEST_OIN}"
+TEST_OIN_VALUE = TEST_OIN.value
 
 MOCK_ORGS = {
     TEST_OIN_WITH_PREFIX: (["nvi"], "irp", "", ""),
@@ -91,7 +92,7 @@ def test_create_happy_path(
             "recipientScope": "nvi",
             "ridUsage": "bsn",
         },
-        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
     assert response.status_code == 201
     assert response.content is not None
@@ -112,7 +113,7 @@ def test_invalid_scope(
             "recipientScope": "invalid-scope",
             "ridUsage": "bsn",
         },
-        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
 
     assert response.status_code == 404
@@ -130,7 +131,7 @@ def test_invalid_scope(
             "recipientScope": "nvi",
             "ridUsage": "bsn",
         },
-        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
 
     assert response.status_code == 404
@@ -153,7 +154,7 @@ def test_decode_as_receiver(
             "recipientScope": "nvi",
             "ridUsage": "bsn",
         },
-        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
     jwe = response.content.decode("utf-8")
     headers, data = decode_jwe(jwe, MOCK_ORGS[TEST_OIN_WITH_PREFIX][2])
@@ -175,7 +176,7 @@ def test_decode_as_receiver(
             "recipientScope": "nvi",
             "ridUsage": "bsn",
         },
-        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
     jwe = response.content.decode("utf-8")
     _, data2 = decode_jwe(jwe, MOCK_ORGS[TEST_OIN_WITH_PREFIX][2])
@@ -197,7 +198,7 @@ def test_receive_rids(
             "recipientScope": "nvi",
             "pseudonymType": "rp",
         },
-        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
     assert response.status_code == 400
     assert response.json() == {"detail": "Invalid RID. Should start with 'rid:'"}
@@ -210,7 +211,7 @@ def test_receive_rids(
             "recipientScope": "nvi",
             "pseudonymType": "rp",
         },
-        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
     assert response.status_code == 400
     assert response.json() == {"detail": "Failed to decrypt RID"}
@@ -229,7 +230,7 @@ def test_receive_incorrect_org(
             "recipientScope": "nvi",
             "ridUsage": "bsn",
         },
-        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
     jwe = response.content.decode("utf-8")
     _, data = decode_jwe(jwe, MOCK_ORGS[TEST_OIN_WITH_PREFIX][2])
@@ -244,7 +245,7 @@ def test_receive_incorrect_org(
             "recipientScope": "nvi",
             "pseudonymType": "rp",
         },
-        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
     assert response.status_code == 400
     assert response.json() == {"detail": "Invalid recipient organization and/or scope"}
@@ -258,7 +259,7 @@ def test_receive_incorrect_org(
             "recipientScope": "incorrect-scope",
             "pseudonymType": "rp",
         },
-        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
     assert response.status_code == 400
     assert response.json() == {"detail": "Invalid recipient organization and/or scope"}
@@ -272,12 +273,56 @@ def test_receive_incorrect_org(
             "recipientScope": "nvi",
             "pseudonymType": "bsn",
         },
-        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
     assert response.status_code == 400
     assert response.json() == {
         "detail": "Organization / scope is not allowed to exchange BSNs"
     }
+
+
+def test_exchange_rid_invalid_recipient_organization_returns_expected_error(
+    client: TestClient, org_service: OrgService, key_resolver: KeyResolver
+) -> None:
+    create_mock_orgs(org_service, key_resolver, MOCK_ORGS)
+
+    response = client.post(
+        "/exchange/rid",
+        json={
+            "personalId": {"landCode": "NL", "type": "bsn", "value": "9500009012"},
+            "recipientOrganization": "not-a-valid-oin",
+            "recipientScope": "nvi",
+            "ridUsage": "bsn",
+        },
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
+    )
+
+    assert response.status_code == 422
+    assert (
+        response.json()["detail"][0]["msg"]
+        == "Invalid recipient organization. Format: oin:<oin_number>"
+    )
+
+
+def test_receive_invalid_recipient_organization_returns_expected_error(
+    client: TestClient,
+) -> None:
+    response = client.post(
+        "/receive",
+        json={
+            "rid": "rid:foobar",
+            "recipientOrganization": "not-a-valid-oin",
+            "recipientScope": "nvi",
+            "pseudonymType": "rp",
+        },
+        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+    )
+
+    assert response.status_code == 422
+    assert (
+        response.json()["detail"][0]["msg"]
+        == "Invalid recipient organization. Format: oin:<oin_number>"
+    )
 
 
 def test_receive_incorrect_usage(
@@ -293,7 +338,7 @@ def test_receive_incorrect_usage(
             "recipientScope": "nvi",
             "ridUsage": "irp",  # Can only be used to exchange for an IRP, not an RP or BSN
         },
-        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
     jwe = response.content.decode("utf-8")
     headers, data = decode_jwe(jwe, MOCK_ORGS[TEST_OIN_WITH_PREFIX][2])
@@ -308,7 +353,7 @@ def test_receive_incorrect_usage(
             "recipientScope": "nvi",
             "pseudonymType": "rp",
         },
-        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
     assert response.status_code == 400
     assert response.json() == {
@@ -324,7 +369,7 @@ def test_receive_incorrect_usage(
             "recipientScope": "nvi",
             "pseudonymType": "bsn",
         },
-        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
     assert response.status_code == 400
     assert response.json() == {
@@ -340,7 +385,7 @@ def test_receive_incorrect_usage(
             "recipientScope": "nvi",
             "pseudonymType": "irp",
         },
-        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
     assert response.status_code == 200
     assert response.json()["type"] == "irp"
@@ -359,7 +404,7 @@ def test_min_usage_level(
             "recipientScope": "nvi",
             "ridUsage": "bsn",
         },
-        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": TEST_OIN_VALUE, "x-gf-audience": "prs.service"},
     )
     jwe = response.content.decode("utf-8")
     headers, data = decode_jwe(jwe, MOCK_ORGS["oin:00000099000000002000"][2])

--- a/tests/test_rid_router.py
+++ b/tests/test_rid_router.py
@@ -5,11 +5,15 @@ from Crypto.PublicKey import RSA
 from jwcrypto import jwe, jwk
 
 from starlette.testclient import TestClient
+from app.models.oin import Oin
 from app.services.key_resolver import KeyResolver
 from app.services.org_service import OrgService
 
+TEST_OIN = Oin("00000099000000001000")
+TEST_OIN_WITH_PREFIX = f"oin:{TEST_OIN}"
+
 MOCK_ORGS = {
-    "oin:00000099000000001000": (["nvi"], "irp", "", ""),
+    TEST_OIN_WITH_PREFIX: (["nvi"], "irp", "", ""),
     "oin:00000099000000002000": (["nvi"], "rp", "", ""),
     "oin:00000099000000003000": (["brp"], "bsn", "", ""),
 }
@@ -47,7 +51,7 @@ def create_mock_orgs(
 ) -> None:
     for oin, org_data in mock_orgs.items():
         stripped_oin = oin.replace("oin:", "")
-        org = org_service.create(stripped_oin, f"MyOrg-{oin}", org_data[1])
+        org = org_service.create(Oin(stripped_oin), f"MyOrg-{oin}", org_data[1])
         if org is None:
             raise RuntimeError(f"Could not create mock org {oin}")
 
@@ -83,11 +87,11 @@ def test_create_happy_path(
         "/exchange/rid",
         json={
             "personalId": {"landCode": "NL", "type": "bsn", "value": "9500009012"},
-            "recipientOrganization": "oin:00000099000000001000",
+            "recipientOrganization": TEST_OIN_WITH_PREFIX,
             "recipientScope": "nvi",
             "ridUsage": "bsn",
         },
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
     )
     assert response.status_code == 201
     assert response.content is not None
@@ -104,16 +108,16 @@ def test_invalid_scope(
         "/exchange/rid",
         json={
             "personalId": {"landCode": "NL", "type": "bsn", "value": "9500009012"},
-            "recipientOrganization": "oin:00000099000000001000",
+            "recipientOrganization": TEST_OIN_WITH_PREFIX,
             "recipientScope": "invalid-scope",
             "ridUsage": "bsn",
         },
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
     )
 
     assert response.status_code == 404
     assert response.json() == {
-        "detail": "No public key found for organization '00000099000000001000' and scope 'invalid-scope'"
+        "detail": f"No public key found for organization '{TEST_OIN}' and scope 'invalid-scope'"
     }
     assert response.headers["Content-Type"] == "application/json"
 
@@ -122,16 +126,16 @@ def test_invalid_scope(
         "/exchange/rid",
         json={
             "personalId": {"landCode": "NL", "type": "bsn", "value": "9500009012"},
-            "recipientOrganization": "oin:1234567823751735703297509312759013275097125",
+            "recipientOrganization": "oin:00000099000000004000",
             "recipientScope": "nvi",
             "ridUsage": "bsn",
         },
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
     )
 
     assert response.status_code == 404
     assert response.json() == {
-        "detail": "Organization with OIN '1234567823751735703297509312759013275097125' not found"
+        "detail": "Organization with OIN '00000099000000004000' not found"
     }
     assert response.headers["Content-Type"] == "application/json"
 
@@ -145,21 +149,21 @@ def test_decode_as_receiver(
         "/exchange/rid",
         json={
             "personalId": {"landCode": "NL", "type": "bsn", "value": "9500009012"},
-            "recipientOrganization": "oin:00000099000000001000",
+            "recipientOrganization": TEST_OIN_WITH_PREFIX,
             "recipientScope": "nvi",
             "ridUsage": "bsn",
         },
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
     )
     jwe = response.content.decode("utf-8")
-    headers, data = decode_jwe(jwe, MOCK_ORGS["oin:00000099000000001000"][2])
+    headers, data = decode_jwe(jwe, MOCK_ORGS[TEST_OIN_WITH_PREFIX][2])
 
     assert headers["enc"] == "A256GCM"
     assert headers["alg"] == "RSA-OAEP-256"
     assert headers["kid"] is not None
 
     assert data["subject"].startswith("rid:")
-    assert data["aud"] == "oin:00000099000000001000"
+    assert data["aud"] == TEST_OIN_WITH_PREFIX
     assert data["scope"] == "nvi"
     assert data["ridUsage"] == "bsn"
 
@@ -167,14 +171,14 @@ def test_decode_as_receiver(
         "/exchange/rid",
         json={
             "personalId": {"landCode": "NL", "type": "bsn", "value": "9500009012"},
-            "recipientOrganization": "oin:00000099000000001000",
+            "recipientOrganization": TEST_OIN_WITH_PREFIX,
             "recipientScope": "nvi",
             "ridUsage": "bsn",
         },
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
     )
     jwe = response.content.decode("utf-8")
-    _, data2 = decode_jwe(jwe, MOCK_ORGS["oin:00000099000000001000"][2])
+    _, data2 = decode_jwe(jwe, MOCK_ORGS[TEST_OIN_WITH_PREFIX][2])
 
     # Make sure a new RID is generated each time
     assert data["subject"] != data2["subject"]
@@ -189,11 +193,11 @@ def test_receive_rids(
         "/receive",
         json={
             "rid": "foobar",
-            "recipientOrganization": "oin:00000099000000001000",
+            "recipientOrganization": TEST_OIN_WITH_PREFIX,
             "recipientScope": "nvi",
             "pseudonymType": "rp",
         },
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
     )
     assert response.status_code == 400
     assert response.json() == {"detail": "Invalid RID. Should start with 'rid:'"}
@@ -202,11 +206,11 @@ def test_receive_rids(
         "/receive",
         json={
             "rid": "rid:foobar",
-            "recipientOrganization": "oin:00000099000000001000",
+            "recipientOrganization": TEST_OIN_WITH_PREFIX,
             "recipientScope": "nvi",
             "pseudonymType": "rp",
         },
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
     )
     assert response.status_code == 400
     assert response.json() == {"detail": "Failed to decrypt RID"}
@@ -221,14 +225,14 @@ def test_receive_incorrect_org(
         "/exchange/rid",
         json={
             "personalId": {"landCode": "NL", "type": "bsn", "value": "9500009012"},
-            "recipientOrganization": "oin:00000099000000001000",
+            "recipientOrganization": TEST_OIN_WITH_PREFIX,
             "recipientScope": "nvi",
             "ridUsage": "bsn",
         },
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
     )
     jwe = response.content.decode("utf-8")
-    _, data = decode_jwe(jwe, MOCK_ORGS["oin:00000099000000001000"][2])
+    _, data = decode_jwe(jwe, MOCK_ORGS[TEST_OIN_WITH_PREFIX][2])
     rid = data["subject"]
 
     # We should not be able to decrypt to incorrect organization
@@ -236,11 +240,11 @@ def test_receive_incorrect_org(
         "/receive",
         json={
             "rid": rid,
-            "recipientOrganization": "oin:32535632532512512",
+            "recipientOrganization": "oin:00000099000000004000",
             "recipientScope": "nvi",
             "pseudonymType": "rp",
         },
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
     )
     assert response.status_code == 400
     assert response.json() == {"detail": "Invalid recipient organization and/or scope"}
@@ -250,11 +254,11 @@ def test_receive_incorrect_org(
         "/receive",
         json={
             "rid": rid,
-            "recipientOrganization": "oin:00000099000000001000",
+            "recipientOrganization": TEST_OIN_WITH_PREFIX,
             "recipientScope": "incorrect-scope",
             "pseudonymType": "rp",
         },
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
     )
     assert response.status_code == 400
     assert response.json() == {"detail": "Invalid recipient organization and/or scope"}
@@ -264,11 +268,11 @@ def test_receive_incorrect_org(
         "/receive",
         json={
             "rid": rid,
-            "recipientOrganization": "oin:00000099000000001000",
+            "recipientOrganization": TEST_OIN_WITH_PREFIX,
             "recipientScope": "nvi",
             "pseudonymType": "bsn",
         },
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
     )
     assert response.status_code == 400
     assert response.json() == {
@@ -285,14 +289,14 @@ def test_receive_incorrect_usage(
         "/exchange/rid",
         json={
             "personalId": {"landCode": "NL", "type": "bsn", "value": "9500009012"},
-            "recipientOrganization": "oin:00000099000000001000",
+            "recipientOrganization": TEST_OIN_WITH_PREFIX,
             "recipientScope": "nvi",
             "ridUsage": "irp",  # Can only be used to exchange for an IRP, not an RP or BSN
         },
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
     )
     jwe = response.content.decode("utf-8")
-    headers, data = decode_jwe(jwe, MOCK_ORGS["oin:00000099000000001000"][2])
+    headers, data = decode_jwe(jwe, MOCK_ORGS[TEST_OIN_WITH_PREFIX][2])
     rid = data["subject"]
 
     # We should not be able to decrypt to RP, even if we are allowed as an organisation
@@ -300,11 +304,11 @@ def test_receive_incorrect_usage(
         "/receive",
         json={
             "rid": rid,
-            "recipientOrganization": "oin:00000099000000001000",
+            "recipientOrganization": TEST_OIN_WITH_PREFIX,
             "recipientScope": "nvi",
             "pseudonymType": "rp",
         },
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
     )
     assert response.status_code == 400
     assert response.json() == {
@@ -316,11 +320,11 @@ def test_receive_incorrect_usage(
         "/receive",
         json={
             "rid": rid,
-            "recipientOrganization": "oin:00000099000000001000",
+            "recipientOrganization": TEST_OIN_WITH_PREFIX,
             "recipientScope": "nvi",
             "pseudonymType": "bsn",
         },
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
     )
     assert response.status_code == 400
     assert response.json() == {
@@ -332,11 +336,11 @@ def test_receive_incorrect_usage(
         "/receive",
         json={
             "rid": rid,
-            "recipientOrganization": "oin:00000099000000001000",
+            "recipientOrganization": TEST_OIN_WITH_PREFIX,
             "recipientScope": "nvi",
             "pseudonymType": "irp",
         },
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
     )
     assert response.status_code == 200
     assert response.json()["type"] == "irp"
@@ -355,7 +359,7 @@ def test_min_usage_level(
             "recipientScope": "nvi",
             "ridUsage": "bsn",
         },
-        headers={"x-gf-oin": "00000099000000001000", "x-gf-audience": "prs.service"},
+        headers={"x-gf-oin": str(TEST_OIN), "x-gf-audience": "prs.service"},
     )
     jwe = response.content.decode("utf-8")
     headers, data = decode_jwe(jwe, MOCK_ORGS["oin:00000099000000002000"][2])


### PR DESCRIPTION
Added new `OinType` for sqlalchemy.
Always use `Oin` class now.

Added `RecipientOrganizationOin` when needing `oin:<oin>` values.

`str(req.recipientOrganization)` will return `oin:<oin>`.
`req.recipientOrganization.value` will return `<oin>`.

The `InvalidOin` exception is now handled through Pydantic validation.