### PR TITLE
OPRF key generation when not exist in the HSM yet

### DIFF
--- a/app/db/repositories/hsm_key_version_repository.py
+++ b/app/db/repositories/hsm_key_version_repository.py
@@ -10,6 +10,7 @@ from app.db.decorator import repository
 from app.db.entities.hsm_key_versions import HsmKeyVersion
 from app.db.entities.organization import Organization
 from app.db.repositories.repository_base import RepositoryBase
+from app.models.oin import Oin
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +18,7 @@ logger = logging.getLogger(__name__)
 @repository(HsmKeyVersion)
 class HsmKeyVersionRepository(RepositoryBase):
     def get_active_versions(
-        self, at: datetime, oin: Optional[str] = None
+        self, at: datetime, oin: Oin | None = None
     ) -> Sequence[HsmKeyVersion]:
         """
         Returns all key versions that are active at the given moment, i.e. not
@@ -35,10 +36,10 @@ class HsmKeyVersionRepository(RepositoryBase):
             )
         )
         if oin is not None:
-            query = query.join(Organization).where(Organization.oin == oin)
+            query = query.join(Organization).where(Organization.oin == oin.value)
         return self.db_session.execute(query).scalars().all()
 
-    def get_by_oin(self, oin: str) -> Sequence[HsmKeyVersion]:
+    def get_by_oin(self, oin: Oin) -> Sequence[HsmKeyVersion]:
         """
         Returns all key versions belonging to the organization with the given OIN,
         regardless of date or removed state, ordered by version number.
@@ -47,7 +48,7 @@ class HsmKeyVersionRepository(RepositoryBase):
             select(HsmKeyVersion)
             .options(joinedload(HsmKeyVersion.organization))
             .join(Organization)
-            .where(Organization.oin == oin)
+            .where(Organization.oin == oin.value)
             .order_by(HsmKeyVersion.version)
         )
         return self.db_session.execute(query).scalars().all()

--- a/app/routers/hsm_key_version.py
+++ b/app/routers/hsm_key_version.py
@@ -7,6 +7,7 @@ from fastapi.encoders import jsonable_encoder
 from starlette.responses import JSONResponse
 
 from app import container
+from app.models.oin import Oin
 from app.models.requests import (
     OIN_PATTERN,
     HsmKeyVersionRequest,
@@ -50,15 +51,15 @@ def post_key_version(
     tags=["Key Version Services"],
 )
 def list_key_versions(
-    oin: Annotated[str, Path(pattern=OIN_PATTERN)],
+    oin: Oin,
     hsm_key_version_service: HsmKeyVersionService = Depends(
         container.get_hsm_key_version_service
     ),
     org_service: OrgService = Depends(container.get_org_service),
 ) -> JSONResponse:
-    org = org_service.get_by_oin(oin)
+    org = org_service.get_by_oin(oin.value)
     if org is None:
-        logger.warning("organization for OIN %r not found", oin)
+        logger.warning("organization for OIN %r not found", oin.value)
         raise HTTPException(status_code=404, detail="organization not found")
 
     versions = hsm_key_version_service.get_versions_for_oin(oin)

--- a/app/services/hsm_key_cleanup_service.py
+++ b/app/services/hsm_key_cleanup_service.py
@@ -3,8 +3,9 @@ import logging
 import requests
 
 from app.config import ConfigOprf
+from app.models.oin import Oin
 from app.services.hsm_key_version_service import HsmKeyVersionService
-from app.services.oprf.oprf_service import oprf_key_label
+from app.services.oprf.oprf_service import HsmKeyLabel
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +38,12 @@ class HsmKeyCleanupService:
         expired = self.__version_service.get_expired_versions()
         cleaned = 0
         for version in expired:
-            label = oprf_key_label(f"oin:{version.oin}", version.version)
+            try:
+                label = HsmKeyLabel(Oin(version.oin), version.version)
+            except ValueError:
+                logger.exception("Value %r is not a correct OIN number", version.oin)
+                continue
+
             try:
                 self._destroy_key(label)
             except Exception:
@@ -53,12 +59,12 @@ class HsmKeyCleanupService:
             logger.info("cleaned up %d expired HSM key version(s)", cleaned)
         return cleaned
 
-    def _destroy_key(self, label: str) -> None:
+    def _destroy_key(self, label: HsmKeyLabel) -> None:
         cfg = self.__hsm_config
         url = f"{cfg.hsm_url}/hsm/{cfg.hsm_module}/{cfg.hsm_slot}/destroy"
         response = requests.post(
             url,
-            json={"label": label},
+            json={"label": str(label)},
             timeout=10,
             verify=cfg.hsm_ca_cert_file or True,
             cert=(

--- a/app/services/hsm_key_version_service.py
+++ b/app/services/hsm_key_version_service.py
@@ -7,6 +7,7 @@ from app.db.db import Database
 from app.db.entities.hsm_key_versions import HsmKeyVersion
 from app.db.repositories.hsm_key_version_repository import HsmKeyVersionRepository
 from app.db.repositories.org_repository import OrgRepository
+from app.models.oin import Oin
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +22,7 @@ class HsmKeyVersionService:
         self.__db = db
 
     def get_active_versions(
-        self, at: datetime | None = None, oin: str | None = None
+        self, at: datetime | None = None, oin: Oin|None = None
     ) -> Sequence[HsmKeyVersion]:
         """
         Returns all key versions that are active at the given moment (defaults to
@@ -33,7 +34,7 @@ class HsmKeyVersionService:
             repo = session.get_repository(HsmKeyVersionRepository)
             return repo.get_active_versions(at, oin)
 
-    def get_versions_for_oin(self, oin: str) -> Sequence[HsmKeyVersion]:
+    def get_versions_for_oin(self, oin: Oin) -> Sequence[HsmKeyVersion]:
         """
         Returns all key versions for the given organization OIN, regardless of
         date or removed state (for administrative listing).

--- a/app/services/oprf/oprf_service.py
+++ b/app/services/oprf/oprf_service.py
@@ -18,7 +18,7 @@ class HsmKeyLabel:
         self.oin = oin
         self.version = version
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"oin-{self.oin}-v{self.version}"
 
 

--- a/app/services/oprf/oprf_service.py
+++ b/app/services/oprf/oprf_service.py
@@ -6,19 +6,20 @@ import requests
 from jwcrypto import jwk
 
 from app.config import ConfigOprf
+from app.models.oin import Oin
 from app.services.hsm_key_version_service import HsmKeyVersionService
 from app.services.oprf.jwe_token import BlindJwe
 from app.models.requests import BlindRequest
 
 logger = logging.getLogger(__name__)
 
+class HsmKeyLabel:
+    def __init__(self, oin: Oin, version: int):
+        self.oin = oin
+        self.version = version
 
-def oprf_key_label(recipient_org: str, version: int) -> str:
-    """
-    The label under which an OPRF key version is stored in the HSM. Shared by
-    OPRF evaluation and the expired-key cleanup so both refer to the same key.
-    """
-    return f"oin-{recipient_org}-v{version}"
+    def __str__(self):
+        return f"oin-{self.oin}-v{self.version}"
 
 
 class OprfService:
@@ -97,9 +98,12 @@ class OprfService:
 
         if self.__hsm_key_version_service is None:
             raise ValueError("HSM key version service not configured")
-
         # The active key versions are stored in the database, keyed by OIN number.
-        oin = recipient_org[4:] if recipient_org.startswith("oin:") else recipient_org
+        try:
+            oin = Oin(recipient_org[4:] if recipient_org.startswith("oin:") else recipient_org)
+        except ValueError as e:
+            raise ValueError("Incorrect OIN: %r", e)
+
         active = self.__hsm_key_version_service.get_active_versions(oin=oin)
         versions = sorted({v.version for v in active})
         if not versions:
@@ -107,14 +111,67 @@ class OprfService:
 
         # Evaluate the blind against every active key version, so the result holds
         # one entry per version (e.g. during key rotation).
-        return {
-            version: self._evaluate_label(
-                oprf_key_label(recipient_org, version), blinded_bytes
-            )
-            for version in versions
-        }
+        ret: dict[int, bytes] = {}
+        for version in versions:
+            label = HsmKeyLabel(oin, version)
+            if not self._label_exists(label):
+                self._generate_key(label)
 
-    def _evaluate_label(self, label: str, blinded_bytes: bytes) -> bytes:
+            ret[version] = self._evaluate_label(label, blinded_bytes)
+
+        return ret
+
+    def _generate_key(self, label: HsmKeyLabel) -> None:
+        cfg = self.__hsm_config
+        if cfg is None:
+            raise ValueError("HSM configuration not found")
+
+        url = f"{cfg.hsm_url}/hsm/{cfg.hsm_module}/{cfg.hsm_slot}/generate/oprf"
+        response = requests.post(
+            url,
+            json={
+                "label": str(label),
+            },
+            timeout=10,
+            verify=cfg.hsm_ca_cert_file or True,
+            cert=(
+                (cfg.hsm_cert_file, cfg.hsm_key_file)
+                if (cfg.hsm_cert_file and cfg.hsm_key_file)
+                else None
+            ),
+        )
+        response.raise_for_status()
+
+        if not 'result' in response.json():
+            raise ValueError("HSM configuration not found")
+
+    def _label_exists(self, label: HsmKeyLabel) -> bool:
+        cfg = self.__hsm_config
+        if cfg is None:
+            raise ValueError("HSM configuration not found")
+
+        url = f"{cfg.hsm_url}/hsm/{cfg.hsm_module}/{cfg.hsm_slot}"
+        response = requests.post(
+            url,
+            json={
+                "label": str(label),
+                "objtype": "SECRET_KEY",
+            },
+            timeout=10,
+            verify=cfg.hsm_ca_cert_file or True,
+            cert=(
+                (cfg.hsm_cert_file, cfg.hsm_key_file)
+                if (cfg.hsm_cert_file and cfg.hsm_key_file)
+                else None
+            ),
+        )
+        response.raise_for_status()
+
+        result = response.json()['objects'] or []
+        return len(result) > 0
+
+
+    def _evaluate_label(self, label: HsmKeyLabel, blinded_bytes: bytes) -> bytes:
         cfg = self.__hsm_config
         if cfg is None:
             raise ValueError("HSM configuration not found")
@@ -123,7 +180,7 @@ class OprfService:
         response = requests.post(
             url,
             json={
-                "label": label,
+                "label": str(label),
                 "blinded_point": base64.b64encode(blinded_bytes).decode(),
             },
             timeout=10,

--- a/tests/test_hsm_key_cleanup_service.py
+++ b/tests/test_hsm_key_cleanup_service.py
@@ -42,7 +42,7 @@ def test_cleanup_removes_expired_keys_from_hsm_and_db(database: Database) -> Non
     # expired for a different org -> should be cleaned up too
     _add(
         database,
-        oin="00000099000000001001",
+        oin="00000099000001001000",
         version=1,
         from_dt=now - timedelta(days=10),
         until_dt=now - timedelta(days=2),
@@ -50,7 +50,7 @@ def test_cleanup_removes_expired_keys_from_hsm_and_db(database: Database) -> Non
     # active (no end date) -> must be left alone
     _add(
         database,
-        oin="00000099000000001000",
+        oin="00000099000001000000",
         version=2,
         from_dt=now - timedelta(days=1),
         until_dt=None,
@@ -58,7 +58,7 @@ def test_cleanup_removes_expired_keys_from_hsm_and_db(database: Database) -> Non
     # already removed -> must be ignored
     _add(
         database,
-        oin="00000099000000001000",
+        oin="00000099000001000000",
         version=3,
         from_dt=now - timedelta(days=5),
         until_dt=now - timedelta(days=1),
@@ -77,8 +77,8 @@ def test_cleanup_removes_expired_keys_from_hsm_and_db(database: Database) -> Non
     # The right keys are destroyed in the HSM, by their stored label.
     labels = {call.kwargs["json"]["label"] for call in post.call_args_list}
     assert labels == {
-        "oin-oin:00000099000000001000-v1",
-        "oin-oin:00000099000000001001-v1",
+        "oin-00000099000000001000-v1",
+        "oin-00000099000001001000-v1",
     }
     urls = {call.args[0] for call in post.call_args_list}
     assert urls == {"https://hsm.local/hsm/softhsm/SoftHSMLabel/destroy"}
@@ -87,14 +87,14 @@ def test_cleanup_removes_expired_keys_from_hsm_and_db(database: Database) -> Non
     version_service = HsmKeyVersionService(database)
     assert version_service.get_expired_versions() == []
     active = {(v.oin, v.version) for v in version_service.get_active_versions()}
-    assert active == {("00000099000000001000", 2)}
+    assert active == {("00000099000001000000", 2)}
 
 
 def test_cleanup_skips_when_hsm_not_configured(database: Database) -> None:
     now = datetime.now(timezone.utc)
     _add(
         database,
-        oin="00000099000000001000",
+        oin="00000099000001000000",
         version=1,
         from_dt=now - timedelta(days=10),
         until_dt=now - timedelta(days=1),
@@ -156,14 +156,14 @@ def test_get_expired_versions_filters(database: Database) -> None:
     )  # active, no end
     _add(
         database,
-        oin="00000099000000001001",
+        oin="00000099000001001000",
         version=1,
         from_dt=now - timedelta(days=2),
         until_dt=now + timedelta(days=1),
     )  # active, future end
     _add(
         database,
-        oin="00000099000000001003",
+        oin="00000099000001003000",
         version=1,
         from_dt=now - timedelta(days=2),
         until_dt=now - timedelta(days=1),

--- a/tests/test_hsm_key_version_integration.py
+++ b/tests/test_hsm_key_version_integration.py
@@ -55,6 +55,15 @@ def _generate_rsa_keypair() -> tuple[str, str]:
 
 def _fake_hsm_post(url: str, json: dict[str, Any], **kwargs: Any) -> MagicMock:
     """Return a distinct evaluation per key version, derived from the label."""
+
+    # Return slot info when asked
+    if url == "https://hsm.local/hsm/softhsm/SoftHSMLabel":
+        resp = MagicMock()
+        resp.json.return_value = {
+            "objects": ["foobar"],
+        }
+        return resp
+
     version = json["label"].rsplit("v", 1)[-1]
     resp = MagicMock()
     resp.json.return_value = {

--- a/tests/test_hsm_key_version_router.py
+++ b/tests/test_hsm_key_version_router.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from starlette.testclient import TestClient
 
 from app.db.db import Database
+from app.models.oin import Oin
 from app.rid import RidUsage
 from app.services.hsm_key_version_service import HsmKeyVersionService
 from app.services.org_service import OrgService
@@ -119,7 +120,7 @@ def test_create_persists_version(
     )
 
     service = HsmKeyVersionService(database)
-    active = service.get_active_versions(oin="00000099000000001000")
+    active = service.get_active_versions(oin=Oin("00000099000000001000"))
     assert [v.version for v in active] == [1]
 
 
@@ -152,7 +153,7 @@ def test_update_sets_removed_and_until_dt(
 
     # The removed version is no longer returned as active.
     service = HsmKeyVersionService(database)
-    assert service.get_active_versions(oin="00000099000000001000") == []
+    assert service.get_active_versions(oin=Oin("00000099000000001000")) == []
 
 
 def test_update_clears_until_dt(

--- a/tests/test_hsm_key_version_service.py
+++ b/tests/test_hsm_key_version_service.py
@@ -1,7 +1,7 @@
 import base64
 import json
 from datetime import datetime, timedelta, timezone
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, call
 
 import pytest
 
@@ -9,8 +9,9 @@ from app.config import ConfigOprf
 from app.db.db import Database
 from app.db.entities.hsm_key_versions import HsmKeyVersion
 from app.db.entities.organization import Organization
+from app.models.oin import Oin
 from app.services.hsm_key_version_service import HsmKeyVersionService
-from app.services.oprf.oprf_service import OprfService
+from app.services.oprf.oprf_service import OprfService, HsmKeyLabel
 
 
 def _add(db: Database, oin: str, **kwargs: object) -> None:
@@ -64,12 +65,12 @@ def test_get_active_versions_filters_by_date_and_removed(database: Database) -> 
 
 def test_eval_via_hsm_returns_entry_per_active_version(database: Database) -> None:
     now = datetime.now(timezone.utc)
-    _add(database, oin="12345678", version=2, from_dt=now - timedelta(days=2))
-    _add(database, oin="12345678", version=7, from_dt=now - timedelta(days=1))
+    _add(database, oin="00000000012345678000", version=2, from_dt=now - timedelta(days=2))
+    _add(database, oin="00000000012345678000", version=7, from_dt=now - timedelta(days=1))
     # a removed version must be ignored
     _add(
         database,
-        oin="12345678",
+        oin="00000000012345678000",
         version=9,
         from_dt=now - timedelta(days=1),
         removed=True,
@@ -81,16 +82,62 @@ def test_eval_via_hsm_returns_entry_per_active_version(database: Database) -> No
         hsm_key_version_service=HsmKeyVersionService(database),
     )
 
-    response = MagicMock()
-    response.json.return_value = {"result": base64.b64encode(b"evaluated").decode()}
-    with patch(
-        "app.services.oprf.oprf_service.requests.post", return_value=response
-    ) as post:
-        result = service._eval_via_hsm("oin:12345678", b"blinded")
+    with (
+        patch.object(service, "_label_exists", return_value=True) as label_exists,
+        patch.object(service, "_evaluate_label", return_value=b"evaluated") as evaluate_label,
+    ):
+        result = service._eval_via_hsm("oin:00000000012345678000", b"blinded")
 
     assert result == {2: b"evaluated", 7: b"evaluated"}
-    labels = {call.kwargs["json"]["label"] for call in post.call_args_list}
-    assert labels == {"oin-oin:12345678-v2", "oin-oin:12345678-v7"}
+
+    assert [str(c.args[0]) for c in label_exists.call_args_list] == [
+        "oin-00000000012345678000-v2",
+        "oin-00000000012345678000-v7",
+    ]
+
+    assert [(str(c.args[0]), c.args[1]) for c in evaluate_label.call_args_list] == [
+        ("oin-00000000012345678000-v2", b"blinded"),
+        ("oin-00000000012345678000-v7", b"blinded"),
+    ]
+
+    assert label_exists.call_count == 2
+    assert evaluate_label.call_count == 2
+
+
+def test_eval_generates_keys_if_needed(database: Database) -> None:
+    now = datetime.now(timezone.utc)
+    _add(database, oin="00000000012345679000", version=1, from_dt=now - timedelta(days=2))
+
+    service = OprfService(
+        server_key=None,
+        hsm_config=ConfigOprf(hsm_url="https://hsm.local"),
+        hsm_key_version_service=HsmKeyVersionService(database),
+    )
+
+    with (
+        patch.object(service, "_label_exists", return_value=False) as label_exists,
+        patch.object(service, "_generate_key") as generate_key,
+        patch.object(service, "_evaluate_label", return_value=b"evaluated") as evaluate_label,
+    ):
+        result = service._eval_via_hsm("oin:00000000012345679000", b"blinded")
+
+    assert result == {1: b"evaluated"}
+
+    assert [str(c.args[0]) for c in label_exists.call_args_list] == [
+        "oin-00000000012345679000-v1",
+    ]
+
+    assert [str(c.args[0]) for c in generate_key.call_args_list] == [
+        "oin-00000000012345679000-v1",
+    ]
+
+    assert [(str(c.args[0]), c.args[1]) for c in evaluate_label.call_args_list] == [
+        ("oin-00000000012345679000-v1", b"blinded"),
+    ]
+
+    assert label_exists.call_count == 1
+    assert evaluate_label.call_count == 1
+    assert generate_key.call_count == 1
 
 
 def test_eval_blind_subject_is_latest_with_extra_versions(database: Database) -> None:
@@ -100,8 +147,8 @@ def test_eval_blind_subject_is_latest_with_extra_versions(database: Database) ->
     from app.models.requests import BlindRequest
 
     now = datetime.now(timezone.utc)
-    _add(database, oin="12345678", version=2, from_dt=now - timedelta(days=2))
-    _add(database, oin="12345678", version=7, from_dt=now - timedelta(days=1))
+    _add(database, oin="00000000012345678000", version=2, from_dt=now - timedelta(days=2))
+    _add(database, oin="00000000012345678000", version=7, from_dt=now - timedelta(days=1))
 
     service = OprfService(
         server_key=None,
@@ -113,6 +160,14 @@ def test_eval_blind_subject_is_latest_with_extra_versions(database: Database) ->
     pub = jwk.JWK.from_json(key.export_public())
 
     def fake_post(url: str, json: dict, **kwargs: object) -> MagicMock:  # type: ignore[type-arg]
+        # Return slot info when asked
+        if url == "https://hsm.local/hsm/softhsm/SoftHSMLabel":
+            resp = MagicMock()
+            resp.json.return_value = {
+                "objects": ["foobar"],
+            }
+            return resp
+
         version = json["label"].rsplit("v", 1)[-1]
         resp = MagicMock()
         resp.json.return_value = {
@@ -122,7 +177,7 @@ def test_eval_blind_subject_is_latest_with_extra_versions(database: Database) ->
 
     req = BlindRequest(
         encryptedPersonalId=base64.urlsafe_b64encode(b"blinded").decode(),
-        recipientOrganization="oin:12345678",
+        recipientOrganization="oin:00000000012345678000",
         recipientScope="scope",
     )
 
@@ -197,6 +252,14 @@ def test_eval_blind_jwe_contains_only_versions_active_at_date(
     pub = jwk.JWK.from_json(key.export_public())
 
     def fake_post(url: str, json: dict, **kwargs: object) -> MagicMock:  # type: ignore[type-arg]
+        # Return slot info when asked
+        if url == "https://hsm.local/hsm/softhsm/SoftHSMLabel":
+            resp = MagicMock()
+            resp.json.return_value = {
+                "objects": ["foobar"],
+            }
+            return resp
+
         version = json["label"].rsplit("v", 1)[-1]
         resp = MagicMock()
         resp.json.return_value = {
@@ -247,4 +310,4 @@ def test_eval_via_hsm_without_service_raises() -> None:
     )
 
     with pytest.raises(ValueError, match="HSM key version service not configured"):
-        service._eval_via_hsm("oin:12345678", b"blinded")
+        service._eval_via_hsm("oin:00000000012345678000", b"blinded")


### PR DESCRIPTION
When keys are not present in the HSM, they will be autoamtically created.

Also, OIN strings are now mostly OIN classes.