### PR TITLE
Small fixes for key_id and update documentation

### DIFF
--- a/app/application.py
+++ b/app/application.py
@@ -60,14 +60,6 @@ TAGS_METADATA = [
         ),
     },
     {
-        "name": "Organizational Services",
-        "description": (
-            "Manage recipient organizations. An organization is identified by its "
-            "OIN and has a `max_key_usage` (`bsn`, `rp`, or `irp`) that caps which "
-            "pseudonym types it is allowed to exchange."
-        ),
-    },
-    {
         "name": "Key Registration Services",
         "description": (
             "Register and manage the public keys that pseudonyms and RIDs are "

--- a/app/db/entities/organization_key.py
+++ b/app/db/entities/organization_key.py
@@ -43,5 +43,5 @@ class OrganizationKey(Base):
             # We omit organization_id since this is an internal detail.
             "scope": self.scope,
             "key_data": self.key_data,
-            "key_id": self.key_id or "",
+            "key_id": self.key_id,
         }

--- a/app/db/repositories/org_key_repository.py
+++ b/app/db/repositories/org_key_repository.py
@@ -96,10 +96,11 @@ class OrganizationKeyRepository(RepositoryBase):
 
     def update(
         self,
-        key_id: uuid.UUID,
+        id: uuid.UUID,
         organization_id: uuid.UUID,
         scope: list[str],
         key_data: str,
+        key_id: str | None,
     ) -> OrganizationKey | None:
         """
         Updates an existing key entry.
@@ -108,11 +109,11 @@ class OrganizationKeyRepository(RepositoryBase):
             update(OrganizationKey)
             .where(
                 and_(
-                    OrganizationKey.id == key_id,
+                    OrganizationKey.id == id,
                     OrganizationKey.organization_id == organization_id,
                 )
             )
-            .values(scope=scope, key_data=key_data)
+            .values(scope=scope, key_data=key_data, key_id=key_id)
             .returning(OrganizationKey)
         )
 
@@ -125,7 +126,7 @@ class OrganizationKeyRepository(RepositoryBase):
         if entry is None:
             logger.warning(
                 "key entry %s for organization_id %s does not exist",
-                key_id,
+                id,
                 organization_id,
             )
             return None

--- a/app/models/requests.py
+++ b/app/models/requests.py
@@ -1,7 +1,7 @@
 import base64
 import logging
 from datetime import datetime, timezone
-from typing import Any, List, Literal
+from typing import Any, List, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 class RegisterRequest(BaseModel):
     scope: List[str]
-    key_id: str | None
+    key_id: Optional[str]
 
 
 class HsmKeyVersionRequest(BaseModel):

--- a/app/models/requests.py
+++ b/app/models/requests.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 class RegisterRequest(BaseModel):
     scope: List[str]
-    key_id: Optional[str]
+    key_id: Optional[str] = None
 
 
 class HsmKeyVersionRequest(BaseModel):

--- a/app/routers/administration/key.py
+++ b/app/routers/administration/key.py
@@ -87,7 +87,7 @@ def put_key(
             id,
             auth_org.id,
             req.scope,
-            req.pub_key,
+            req.key_data,
             req.key_id,
         )
     except KeyNotFoundError:

--- a/app/routers/administration/key.py
+++ b/app/routers/administration/key.py
@@ -72,27 +72,28 @@ def list_keys_for_org(
 
 
 @router.put(
-    "/keys/{key_id}",
+    "/keys/{id}",
     summary="Update a key for the authorized organization",
     tags=["Key Registration Services"],
 )
 def put_key(
-    key_id: Annotated[UUID, Path(title="The ID of the key to update")],
+    id: Annotated[UUID, Path(title="The ID of the key to update")],
     req: KeyRequest,
     auth_org: Annotated[Organization, Depends(authenticated_organization)],
     key_resolver: Annotated[KeyResolver, Depends(container.get_key_resolver)],
 ) -> JSONResponse:
     try:
         updated = key_resolver.update(
-            key_id,
+            id,
             auth_org.id,
             req.scope,
             req.pub_key,
+            req.key_id,
         )
     except KeyNotFoundError:
         logger.warning(
             "key %s not found for organization %s",
-            key_id,
+            id,
             auth_org.id,
         )
         raise HTTPException(status_code=403, detail="forbidden")
@@ -104,28 +105,26 @@ def put_key(
             status_code=409, detail="key for this org/scope already exists"
         )
     except Exception:
-        logger.exception("failed to update key %s", key_id)
+        logger.exception("failed to update key %s", id)
         raise HTTPException(status_code=500, detail="failed to update key")
 
     return JSONResponse(status_code=200, content=updated.to_dict())
 
 
 @router.delete(
-    "/keys/{key_id}",
+    "/keys/{id}",
     summary="Delete a key for the authorized organization",
     tags=["Key Registration Services"],
 )
 def delete_key(
-    key_id: Annotated[UUID, Path(title="The ID of the key to delete")],
+    id: Annotated[UUID, Path(title="The ID of the key to delete")],
     auth_org: Annotated[Organization, Depends(authenticated_organization)],
     key_resolver: Annotated[KeyResolver, Depends(container.get_key_resolver)],
 ) -> JSONResponse:
-    deleted = key_resolver.delete(key_id, auth_org.id)
+    deleted = key_resolver.delete(id, auth_org.id)
     if not deleted:
-        logger.warning(
-            "key %s for organization %s was not deleted", key_id, auth_org.id
-        )
+        logger.warning("key %s for organization %s was not deleted", id, auth_org.id)
         raise HTTPException(status_code=403, detail="forbidden")
 
-    logger.info("key with id %s deleted successfully", key_id)
+    logger.info("key with id %s deleted successfully", id)
     return JSONResponse(status_code=200, content={"message": "key deleted"})

--- a/app/services/key_resolver.py
+++ b/app/services/key_resolver.py
@@ -34,7 +34,7 @@ class KeyRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     scope: List[str] = Field(...)
-    pub_key: str = Field(..., min_length=32)
+    key_data: str = Field(..., min_length=32)
     key_id: Optional[str] = None
     max_key_usage: Optional[RidUsage] = None
 
@@ -50,9 +50,9 @@ class KeyRequest(BaseModel):
             raise ValueError("scope contains only empty/invalid items")
         return norm
 
-    @field_validator("pub_key")
+    @field_validator("key_data")
     @classmethod
-    def validate_pub_key(cls, v: str) -> str:
+    def validate_key_data(cls, v: str) -> str:
         try:
             key = jwk.JWK.from_pem(v.strip().encode("ascii"))
         except Exception as e:

--- a/app/services/key_resolver.py
+++ b/app/services/key_resolver.py
@@ -7,7 +7,9 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from app.db.db import Database
 from app.db.entities.organization_key import OrganizationKey
-from app.db.repositories.org_key_repository import OrganizationKeyRepository
+from app.db.repositories.org_key_repository import (
+    OrganizationKeyRepository,
+)
 from app.db.repositories.org_repository import OrgRepository
 from app.models.oin import Oin
 from app.rid import RidUsage
@@ -33,6 +35,7 @@ class KeyRequest(BaseModel):
 
     scope: List[str] = Field(...)
     pub_key: str = Field(..., min_length=32)
+    key_id: Optional[str] = None
     max_key_usage: Optional[RidUsage] = None
 
     @field_validator("scope")
@@ -125,40 +128,42 @@ class KeyResolver:
 
     def update(
         self,
-        key_id: uuid.UUID,
+        id: uuid.UUID,
         organization_id: uuid.UUID,
         scope: list[str],
         key_data: str,
+        key_id: str | None,
     ) -> OrganizationKey:
         scope = _normalize_scope(scope)
 
         with self.db.get_db_session() as session:
             repository = session.get_repository(OrganizationKeyRepository)
 
-            existing = repository.has_overlapping_scope(organization_id, scope, key_id)
+            existing = repository.has_overlapping_scope(organization_id, scope, id)
             if existing:
                 raise AlreadyExistsError(
                     f"key for org/scope already exists: scope {scope}"
                 )
 
             entry = repository.update(
-                key_id,
+                id,
                 organization_id,
                 scope,
                 key_data,
+                key_id,
             )
             if entry is None:
-                current = repository.get_by_id(key_id)
+                current = repository.get_by_id(id)
                 if current is not None and current.organization_id != organization_id:
                     logger.warning(
                         "caller org %s attempted to update key %s owned by org %s",
                         organization_id,
-                        key_id,
+                        id,
                         current.organization_id,
                     )
 
                 raise KeyNotFoundError(
-                    f"key {key_id} not found for organization {organization_id}"
+                    f"key {id} not found for organization {organization_id}"
                 )
             session.commit()
             return entry

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -49,7 +49,7 @@ Update the scope/key data for a specific key. Include `key_id` to change the key
 {
   "scope": ["bar", "baz"],
   "key_id": "k2",
-  "pub_key": "-----BEGIN PUBLIC KEY----- ... -----END PUBLIC KEY-----\\n"
+  "key_data": "-----BEGIN PUBLIC KEY----- ... -----END PUBLIC KEY-----\\n"
 }
 ```
 

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -6,53 +6,93 @@ This document lists the main service endpoints. The testing/helper endpoints (`/
 
 A recipient organization is always identified by a OIN in the form `oin:<20 digits>` (e.g. `oin:00000099000000001000`).
 
-## Organizational Services
+## Administration Services
 
-#### `POST /orgs`
-Create a new organization.
+These endpoints are under `/administration` and require OAuth authorization. `POST /administration/register/certificate` additionally uses mTLS: the public key is taken from the caller's TLS client certificate.
 
-```json
-{
-  "oin": "00000099000000001000",
-  "name": "Example Organization",
-  "max_key_usage": "irp"
-}
-```
-
-`max_key_usage` is one of `bsn`, `rp`, or `irp` and caps which pseudonym types the organization may exchange.
-
-#### `GET /org/{oin}`
-Return the organization for the given OIN (digits only, e.g. `00000099000000001000`).
-
-#### `PUT /org/{oin}`
-Update an organization's `name` and `max_key_usage`.
-
-#### `DELETE /org/{oin}`
-Delete an organization (and its keys).
-
-## Key Registration Services
-
-These endpoints are protected by mutual TLS. The organization and its public key are derived from the client certificate, so they are not part of the request body.
-
-#### `POST /register/certificate`
+#### `POST /administration/register/certificate`
 Register the public key (taken from the mTLS client certificate) for one or more scopes of the calling organization.
 
 ```json
 {
-  "scope": ["bar"]
+  "scope": ["bar"],
+  "key_id": "k1"
 }
 ```
 
+`scope` must contain at least one entry. A `*` scope is a wildcard and matches all recipient scopes.
+
+`scope` values are normalized to lowercase and deduplicated.
+
+`key_id` is optional. It is included as the `kid` header in the `/oprf/eval` JWE response.
+
 Returns `201` on success, `409` if a key for that organization/scope already exists.
 
-#### `GET /keys/{oin}`
-List the registered public keys for an organization.
+#### `GET /administration/keys`
+List the registered public keys for the authenticated organization.
 
-#### `PUT /keys/{key_id}`
-Update the scope/key data for a specific key.
+```json
+[
+  {
+    "id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+    "scope": ["bar"],
+    "key_data": "-----BEGIN PUBLIC KEY----- ... -----END PUBLIC KEY-----\\n",
+    "key_id": "k1"
+  }
+]
+```
 
-#### `DELETE /keys/{key_id}`
+#### `PUT /administration/keys/{id}`
+Update the scope/key data for a specific key. Include `key_id` to change the key identifier; set it to `null` (or omit it) to clear it.
+
+```json
+{
+  "scope": ["bar", "baz"],
+  "key_id": "k2",
+  "pub_key": "-----BEGIN PUBLIC KEY----- ... -----END PUBLIC KEY-----\\n"
+}
+```
+
+#### `DELETE /administration/keys/{id}`
 Delete a specific key.
+
+#### `POST /administration/key-versions`
+Create a new HSM key version for the authenticated organization.
+
+```json
+{
+  "from_dt": "2026-01-01T00:00:00+00:00",
+  "until_dt": "2027-01-01T00:00:00+01:00"
+}
+```
+
+`from_dt` and `until_dt` are optional when omitted; when provided they must include a timezone offset.
+
+```json
+{
+  "id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+  "version": 1,
+  "from_dt": "2026-01-01T00:00:00+00:00",
+  "until_dt": "2027-01-01T00:00:00+01:00",
+  "removed": false
+}
+```
+
+Returns `201` on success.
+
+#### `GET /administration/key-versions`
+List all HSM key versions for the authenticated organization.
+
+#### `PUT /administration/key-versions/{id}`
+Update the end date for one key version.
+
+```json
+{
+  "until_dt": "2027-01-01T00:00:00+03:00"
+}
+```
+
+`until_dt` may also be set to `null` to clear the existing end date.
 
 ## Exchange Services
 

--- a/tests/test_key_resolver.py
+++ b/tests/test_key_resolver.py
@@ -32,9 +32,9 @@ def test_resolver_create_and_resolve_roundtrip(
     # create
     req = KeyRequest(
         scope=["NVI", " lmr "],
-        pub_key=TEST_PUBKEY,
+        key_data=TEST_PUBKEY,
     )
-    entry = key_resolver.create(org.id, req.scope, "my-key-id", req.pub_key)
+    entry = key_resolver.create(org.id, req.scope, "my-key-id", req.key_data)
 
     assert entry.organization_id == org.id
     assert sorted(entry.scope) == ["lmr", "nvi"]
@@ -113,13 +113,20 @@ def test_key_request_rejects_extra_field_with_validation_error() -> None:
         KeyRequest.model_validate(
             {
                 "scope": ["nvi"],
-                "pub_key": TEST_PUBKEY,
+                "key_data": TEST_PUBKEY,
                 "organization": TEST_OIN,
             }
         )
 
     e = exc.value
     assert "extra_forbidden" in str(e)
+
+
+def test_key_request_rejects_pub_key_field_after_rename() -> None:
+    with pytest.raises(ValidationError) as exc:
+        KeyRequest.model_validate({"scope": ["nvi"], "pub_key": TEST_PUBKEY})
+
+    assert "extra_forbidden" in str(exc.value)
 
 
 def test_update_repository_level_does_not_modify_other_organization_key(

--- a/tests/test_key_resolver.py
+++ b/tests/test_key_resolver.py
@@ -105,8 +105,7 @@ def test_resolver_create_without_key_id(
     stored = key_resolver.get_by_id(entry.id)
     assert stored is not None
     assert stored.key_id is None
-    # to_dict() represents a missing key_id as an empty string
-    assert stored.to_dict()["key_id"] == ""
+    assert stored.to_dict()["key_id"] is None
 
 
 def test_key_request_rejects_extra_field_with_validation_error() -> None:
@@ -147,6 +146,7 @@ def test_update_repository_level_does_not_modify_other_organization_key(
                 other_org.id,
                 ["nvi"],
                 TEST_PUBKEY,
+                None,
             )
             is None
         )

--- a/tests/test_key_router.py
+++ b/tests/test_key_router.py
@@ -189,7 +189,7 @@ def test_list_keys_for_org_without_keys_returns_empty(
     assert response.json() == []
 
 
-def test_update_key_updates_scope_and_data_for_authenticated_org(
+def test_update_key_clears_key_id_when_not_provided(
     client: TestClient,
     org_service: OrgService,
     key_resolver: KeyResolver,
@@ -219,11 +219,80 @@ def test_update_key_updates_scope_and_data_for_authenticated_org(
     assert body["id"] == str(created.id)
     assert body["scope"] == ["brp", "nvi"]
     assert body["key_data"] == new_key_data
-    assert body["key_id"] == "old"
+    assert body["key_id"] is None
 
     updated = key_resolver.get_by_id(created.id)
     assert updated is not None
     assert updated.key_data == new_key_data
+    assert updated.key_id is None
+
+
+def test_update_key_updates_key_id_for_authenticated_org(
+    client: TestClient,
+    org_service: OrgService,
+    key_resolver: KeyResolver,
+    valid_headers: Dict[str, str],
+) -> None:
+    auth_org = org_service.create(
+        Oin("00000099000000001000"),
+        "MyOrg A",
+        RidUsage.IrreversiblePseudonym,
+    )
+    old_key_data = _generate_rsa_public_key()
+    created = key_resolver.create(auth_org.id, ["nvi"], "old", old_key_data)
+
+    response = client.put(
+        f"/administration/keys/{created.id}",
+        json={
+            "scope": ["nvi"],
+            "pub_key": old_key_data,
+            "key_id": "new",
+        },
+        headers=_auth_headers(valid_headers, auth_org.oin),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == str(created.id)
+    assert body["key_id"] == "new"
+
+    updated = key_resolver.get_by_id(created.id)
+    assert updated is not None
+    assert updated.key_id == "new"
+
+
+def test_update_key_clears_key_id_when_null(
+    client: TestClient,
+    org_service: OrgService,
+    key_resolver: KeyResolver,
+    valid_headers: Dict[str, str],
+) -> None:
+    auth_org = org_service.create(
+        Oin("00000099000000001000"),
+        "MyOrg A",
+        RidUsage.IrreversiblePseudonym,
+    )
+    old_key_data = _generate_rsa_public_key()
+    created = key_resolver.create(auth_org.id, ["nvi"], "old", old_key_data)
+
+    response = client.put(
+        f"/administration/keys/{created.id}",
+        json={
+            "scope": ["nvi"],
+            "pub_key": old_key_data,
+            "key_id": None,
+        },
+        headers=_auth_headers(valid_headers, auth_org.oin),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == str(created.id)
+    assert body["key_id"] is None
+
+    updated = key_resolver.get_by_id(created.id)
+    assert updated is not None
+    assert updated.key_id is None
 
 
 def test_update_unknown_key_is_unauthorized(

--- a/tests/test_key_router.py
+++ b/tests/test_key_router.py
@@ -209,7 +209,7 @@ def test_update_key_clears_key_id_when_not_provided(
         f"/administration/keys/{created.id}",
         json={
             "scope": ["nvi", "brp"],
-            "pub_key": new_key_data,
+            "key_data": new_key_data,
         },
         headers=_auth_headers(valid_headers, auth_org.oin),
     )
@@ -245,7 +245,7 @@ def test_update_key_updates_key_id_for_authenticated_org(
         f"/administration/keys/{created.id}",
         json={
             "scope": ["nvi"],
-            "pub_key": old_key_data,
+            "key_data": old_key_data,
             "key_id": "new",
         },
         headers=_auth_headers(valid_headers, auth_org.oin),
@@ -279,7 +279,7 @@ def test_update_key_clears_key_id_when_null(
         f"/administration/keys/{created.id}",
         json={
             "scope": ["nvi"],
-            "pub_key": old_key_data,
+            "key_data": old_key_data,
             "key_id": None,
         },
         headers=_auth_headers(valid_headers, auth_org.oin),
@@ -310,7 +310,7 @@ def test_update_unknown_key_is_unauthorized(
         f"/administration/keys/{uuid.uuid4()}",
         json={
             "scope": ["nvi"],
-            "pub_key": _generate_rsa_public_key(),
+            "key_data": _generate_rsa_public_key(),
         },
         headers=_auth_headers(valid_headers, auth_org.oin),
     )
@@ -343,7 +343,7 @@ def test_update_other_org_is_unauthorized(
         f"/administration/keys/{created.id}",
         json={
             "scope": ["nvi"],
-            "pub_key": _generate_rsa_public_key(),
+            "key_data": _generate_rsa_public_key(),
         },
         headers=_auth_headers(valid_headers, auth_org.oin),
     )
@@ -446,7 +446,7 @@ def test_update_rejects_invalid_key_id_with_422(
         "/administration/keys/not-a-uuid",
         json={
             "scope": ["nvi"],
-            "pub_key": _generate_rsa_public_key(),
+            "key_data": _generate_rsa_public_key(),
         },
         headers=_auth_headers(valid_headers, auth_org.oin),
     )
@@ -473,7 +473,7 @@ def test_update_rejects_extra_field_with_422(
         f"/administration/keys/{created.id}",
         json={
             "scope": ["nvi"],
-            "pub_key": _generate_rsa_public_key(),
+            "key_data": _generate_rsa_public_key(),
             "organization": auth_org.oin.value,
         },
         headers=_auth_headers(valid_headers, auth_org.oin),

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -126,12 +126,10 @@ def test_register_request_key_id_may_be_none() -> None:
     assert request.key_id is None
 
 
-def test_register_request_key_id_is_required() -> None:
-    try:
-        RegisterRequest(scope=["nvi"])  # type: ignore[call-arg]
-        assert False, "Expected ValidationError when key_id is missing"
-    except ValidationError as e:
-        assert "key_id" in str(e)
+def test_register_request_key_id_defaults_to_none() -> None:
+    request = RegisterRequest(scope=["nvi"])
+
+    assert request.key_id is None
 
 
 def test_hsm_key_version_request_from_dt_must_not_be_in_the_past() -> None:


### PR DESCRIPTION
This changes the key id route parameter to `id` so people know that the `id` (uuid) is different from the `key_id` (str) that is used as `kid` in the JWE response.

Updated documentation with the route changes.

It was already possible to update the `key_data`, now it is also possible to update the `key_id`.
Rename `pub_key` to `key_data` so the request matches with the response.