### PR TITLE
Use RSA-OAEP instead of RSA-OAEP-256

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ To use this system:
       "jwe": {
         "headers": {
           "kid": "rNv1O_mXgxF6QEMfaQGvjev7RbT1FG3sJXxxsu_KHbM",
-          "alg": "RSA-OAEP-256",
+          "alg": "RSA-OAEP",
           "enc": "A256GCM",
           "cty": "application/json"
         },

--- a/app/services/oprf/jwe_token.py
+++ b/app/services/oprf/jwe_token.py
@@ -31,7 +31,7 @@ class BlindJwe:
 
         protected_headers = {
             "kid": pub_key_id if pub_key_id else pub_key.thumbprint(),
-            "alg": "RSA-OAEP-256",
+            "alg": "RSA-OAEP",
             "enc": "A256GCM",
             "cty": "application/json",
         }

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -60,7 +60,7 @@ Response:
   "jwe": {
     "headers": {
       "kid": "apcsz4HE6UYny5RiSh6aEIp7N_Cb2EGStknChLJTuug",
-      "alg": "RSA-OAEP-256",
+      "alg": "RSA-OAEP",
       "enc": "A256GCM",
       "cty": "application/json"
     },
@@ -129,7 +129,7 @@ Response:
   "jwe": {
     "headers": {
       "kid": "apcsz4HE6UYny5RiSh6aEIp7N_Cb2EGStknChLJTuug",
-      "alg": "RSA-OAEP-256",
+      "alg": "RSA-OAEP",
       "enc": "A256GCM",
       "cty": "application/json"
     },

--- a/tests/test_rid_router.py
+++ b/tests/test_rid_router.py
@@ -166,7 +166,7 @@ def test_decode_as_receiver(
     headers, data = decode_jwe(jwe, MOCK_ORGS[TEST_OIN_WITH_PREFIX][2])
 
     assert headers["enc"] == "A256GCM"
-    assert headers["alg"] == "RSA-OAEP-256"
+    assert headers["alg"] == "RSA-OAEP"
     assert headers["kid"] is not None
 
     assert data["subject"].startswith("rid:")


### PR DESCRIPTION
This PR changes the encryption algorithm of the response JWE to RSA-OAEP instead of RSA-OAEP-256.

The usage of SHA1 with OAEP does not create a vulnerability. This will be in detail explained in the TO